### PR TITLE
feat: 서버 프리페칭 및 HydrationBoundary 적용

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,6 +18,9 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/src/app/api/library/route.ts
+++ b/src/app/api/library/route.ts
@@ -1,41 +1,19 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-
-const ODCLOUD_API_URL = process.env.ODCLOUD_API_URL;
-const ODCLOUD_API_KEY = process.env.ODCLOUD_API_KEY;
-const LIBRARY_DATASET_PATH =
-  '/api/15044146/v1/uddi:7894ac31-fe17-420a-834a-824c42470e0e_201905301141';
+import { servFetchLibraryItemsServer } from '@/services/library/library-services';
 
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
-  const page = searchParams.get('page') ?? '1';
-  const perPage = searchParams.get('perPage') ?? '30';
+  const page = Number(searchParams.get('page') ?? '1');
+  const perPage = Number(searchParams.get('perPage') ?? '30');
 
-  if (!ODCLOUD_API_URL || !ODCLOUD_API_KEY) {
+  try {
+    const items = await servFetchLibraryItemsServer(page, perPage);
+    return NextResponse.json({ data: items });
+  } catch {
     return NextResponse.json(
-      { error: 'Server configuration error' },
+      { error: '공공데이터 API 요청 실패' },
       { status: 500 }
     );
   }
-
-  const params = new URLSearchParams({
-    page,
-    perPage,
-    returnType: 'JSON',
-    serviceKey: ODCLOUD_API_KEY,
-  });
-
-  const response = await fetch(
-    `${ODCLOUD_API_URL}${LIBRARY_DATASET_PATH}?${params.toString()}`
-  );
-
-  if (!response.ok) {
-    return NextResponse.json(
-      { error: '공공데이터 API 요청 실패' },
-      { status: response.status }
-    );
-  }
-
-  const data: unknown = await response.json();
-  return NextResponse.json(data);
 }

--- a/src/app/board/[id]/components/BoardDetailContents.tsx
+++ b/src/app/board/[id]/components/BoardDetailContents.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Image from 'next/image';
+import Link from 'next/link';
+import {
+  Card,
+  Text,
+  Title,
+  Stack,
+  Group,
+  Avatar,
+  TextInput,
+  Divider,
+  Center,
+  Loader,
+  Alert,
+  ActionIcon,
+  ScrollArea,
+} from '@mantine/core';
+import { IconTrash, IconSend } from '@tabler/icons-react';
+import {
+  useBoardDetail,
+  useDeleteBoardPost,
+  useAddBoardComment,
+} from '@/services/board/useBoard';
+import { useUser } from '@/services/auth/useUser';
+
+export default function BoardDetailContents() {
+  const { id } = useParams<{ id: string }>();
+  const postId = Number(id);
+  const router = useRouter();
+  const { user } = useUser();
+  const [comment, setComment] = useState('');
+
+  const { data, isLoading } = useBoardDetail(postId);
+  const deleteMutation = useDeleteBoardPost();
+  const commentMutation = useAddBoardComment();
+
+  if (isLoading) {
+    return (
+      <Center className="min-h-[60vh]">
+        <Loader size="lg" />
+      </Center>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Alert color="red" className="mx-auto mt-10 max-w-md">
+        게시글을 찾을 수 없습니다.
+      </Alert>
+    );
+  }
+
+  const { post, comments } = data;
+  const isAuthor = user?.id === post.user_id;
+
+  function handleDelete() {
+    if (!user) return;
+    deleteMutation.mutate(postId, {
+      onSuccess: () => router.push('/board'),
+    });
+  }
+
+  function handleComment() {
+    if (!comment.trim() || !user) return;
+    commentMutation.mutate(
+      { postId, content: comment },
+      { onSuccess: () => setComment('') }
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <Card shadow="sm" radius="md" withBorder>
+        <Card.Section className="border-b border-gray-200 p-4">
+          <Text fw={600}>도담덕 정보 나눔 게시판</Text>
+        </Card.Section>
+
+        <div className="flex flex-col gap-6 p-6 md:flex-row">
+          <div className="flex flex-col gap-4 md:w-1/2">
+            <div className="relative aspect-square overflow-hidden rounded-md">
+              <Image
+                src={post.image_url || '/images/도담덕로고.png'}
+                alt={post.title}
+                fill
+                className="object-cover"
+                unoptimized
+              />
+            </div>
+
+            <Group>
+              <Avatar
+                src={post.profiles.profile_url || undefined}
+                size="lg"
+                radius="xl"
+              />
+              <Stack gap={2}>
+                <Text fw={600}>{post.profiles.display_name} 님</Text>
+                <Text size="xs" c="dimmed">
+                  {post.created_at}
+                </Text>
+              </Stack>
+            </Group>
+          </div>
+
+          <Divider orientation="vertical" className="hidden md:block" />
+
+          <div className="flex flex-1 flex-col">
+            <Group justify="space-between">
+              <Title order={3}>{post.title}</Title>
+              {isAuthor && (
+                <ActionIcon
+                  variant="subtle"
+                  color="red"
+                  onClick={handleDelete}
+                  loading={deleteMutation.isPending}
+                >
+                  <IconTrash size={18} />
+                </ActionIcon>
+              )}
+            </Group>
+            <Text size="xs" c="dimmed" className="mt-1">
+              조회 {post.views}
+            </Text>
+
+            <Text className="mt-4 whitespace-pre-wrap">{post.content}</Text>
+
+            <Divider className="my-6" />
+
+            <Text fw={600} className="mb-3">
+              댓글
+            </Text>
+            <ScrollArea.Autosize mah={300} className="scrollbar-brand">
+              <Stack gap="sm">
+                {comments.map((c) => (
+                  <div key={c.id}>
+                    <Group gap="xs">
+                      <Text size="sm" fw={600}>
+                        {c.profiles.display_name}
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        {c.created_at}
+                      </Text>
+                    </Group>
+                    <Text size="sm" className="mt-1">
+                      {c.content}
+                    </Text>
+                  </div>
+                ))}
+                {comments.length === 0 && (
+                  <Text size="sm" c="dimmed">
+                    아직 댓글이 없습니다.
+                  </Text>
+                )}
+              </Stack>
+            </ScrollArea.Autosize>
+
+            {user && (
+              <Group className="mt-4">
+                <TextInput
+                  placeholder="댓글을 입력해주세요."
+                  value={comment}
+                  onChange={(e) => setComment(e.currentTarget.value)}
+                  className="flex-1"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleComment();
+                  }}
+                />
+                <ActionIcon
+                  onClick={handleComment}
+                  loading={commentMutation.isPending}
+                  variant="filled"
+                >
+                  <IconSend size={16} />
+                </ActionIcon>
+              </Group>
+            )}
+          </div>
+        </div>
+
+        <Card.Section className="border-t border-gray-200 p-4">
+          <Text
+            component={Link}
+            href="/board"
+            size="sm"
+            c="dimmed"
+            className="cursor-pointer hover:underline"
+          >
+            게시글 목록보기
+          </Text>
+        </Card.Section>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/board/[id]/page.tsx
+++ b/src/app/board/[id]/page.tsx
@@ -1,198 +1,30 @@
-'use client';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import getQueryClient from '@/libs/query/query-client';
+import { createClient } from '@/libs/supabase/server';
+import { boardQueries } from '@/services/board/queries';
+import { servFetchBoardDetail } from '@/services/board/board-services';
+import BoardDetailContents from './components/BoardDetailContents';
 
-import { useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import Image from 'next/image';
-import Link from 'next/link';
-import {
-  Card,
-  Text,
-  Title,
-  Stack,
-  Group,
-  Avatar,
-  TextInput,
-  Divider,
-  Center,
-  Loader,
-  Alert,
-  ActionIcon,
-  ScrollArea,
-} from '@mantine/core';
-import { IconTrash, IconSend } from '@tabler/icons-react';
-import {
-  useBoardDetail,
-  useDeleteBoardPost,
-  useAddBoardComment,
-} from '@/services/board/useBoard';
-import { useUser } from '@/services/auth/useUser';
+interface BoardDetailPageProps {
+  params: Promise<{ id: string }>;
+}
 
-export default function BoardDetailPage() {
-  const { id } = useParams<{ id: string }>();
+export default async function BoardDetailPage({
+  params,
+}: BoardDetailPageProps) {
+  const { id } = await params;
   const postId = Number(id);
-  const router = useRouter();
-  const { user } = useUser();
-  const [comment, setComment] = useState('');
+  const queryClient = getQueryClient();
+  const supabase = await createClient();
 
-  const { data, isLoading } = useBoardDetail(postId);
-  const deleteMutation = useDeleteBoardPost();
-  const commentMutation = useAddBoardComment();
-
-  if (isLoading) {
-    return (
-      <Center className="min-h-[60vh]">
-        <Loader size="lg" />
-      </Center>
-    );
-  }
-
-  if (!data) {
-    return (
-      <Alert color="red" className="mx-auto mt-10 max-w-md">
-        게시글을 찾을 수 없습니다.
-      </Alert>
-    );
-  }
-
-  const { post, comments } = data;
-  const isAuthor = user?.id === post.user_id;
-
-  function handleDelete() {
-    if (!user) return;
-    deleteMutation.mutate(postId, {
-      onSuccess: () => router.push('/board'),
-    });
-  }
-
-  function handleComment() {
-    if (!comment.trim() || !user) return;
-    commentMutation.mutate(
-      { postId, content: comment },
-      { onSuccess: () => setComment('') }
-    );
-  }
+  await queryClient.prefetchQuery({
+    ...boardQueries.detail(postId),
+    queryFn: () => servFetchBoardDetail(postId, supabase),
+  });
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-10">
-      <Card shadow="sm" radius="md" withBorder>
-        <Card.Section className="border-b border-gray-200 p-4">
-          <Text fw={600}>도담덕 정보 나눔 게시판</Text>
-        </Card.Section>
-
-        <div className="flex flex-col gap-6 p-6 md:flex-row">
-          <div className="flex flex-col gap-4 md:w-1/2">
-            <div className="relative aspect-square overflow-hidden rounded-md">
-              <Image
-                src={post.image_url || '/images/도담덕로고.png'}
-                alt={post.title}
-                fill
-                className="object-cover"
-                unoptimized
-              />
-            </div>
-
-            <Group>
-              <Avatar
-                src={post.profiles.profile_url || undefined}
-                size="lg"
-                radius="xl"
-              />
-              <Stack gap={2}>
-                <Text fw={600}>{post.profiles.display_name} 님</Text>
-                <Text size="xs" c="dimmed">
-                  {post.created_at}
-                </Text>
-              </Stack>
-            </Group>
-          </div>
-
-          <Divider orientation="vertical" className="hidden md:block" />
-
-          <div className="flex flex-1 flex-col">
-            <Group justify="space-between">
-              <Title order={3}>{post.title}</Title>
-              {isAuthor && (
-                <ActionIcon
-                  variant="subtle"
-                  color="red"
-                  onClick={handleDelete}
-                  loading={deleteMutation.isPending}
-                >
-                  <IconTrash size={18} />
-                </ActionIcon>
-              )}
-            </Group>
-            <Text size="xs" c="dimmed" className="mt-1">
-              조회 {post.views}
-            </Text>
-
-            <Text className="mt-4 whitespace-pre-wrap">{post.content}</Text>
-
-            <Divider className="my-6" />
-
-            <Text fw={600} className="mb-3">
-              댓글
-            </Text>
-            <ScrollArea.Autosize mah={300} className="scrollbar-brand">
-              <Stack gap="sm">
-                {comments.map((c) => (
-                  <div key={c.id}>
-                    <Group gap="xs">
-                      <Text size="sm" fw={600}>
-                        {c.profiles.display_name}
-                      </Text>
-                      <Text size="xs" c="dimmed">
-                        {c.created_at}
-                      </Text>
-                    </Group>
-                    <Text size="sm" className="mt-1">
-                      {c.content}
-                    </Text>
-                  </div>
-                ))}
-                {comments.length === 0 && (
-                  <Text size="sm" c="dimmed">
-                    아직 댓글이 없습니다.
-                  </Text>
-                )}
-              </Stack>
-            </ScrollArea.Autosize>
-
-            {user && (
-              <Group className="mt-4">
-                <TextInput
-                  placeholder="댓글을 입력해주세요."
-                  value={comment}
-                  onChange={(e) => setComment(e.currentTarget.value)}
-                  className="flex-1"
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleComment();
-                  }}
-                />
-                <ActionIcon
-                  onClick={handleComment}
-                  loading={commentMutation.isPending}
-                  variant="filled"
-                >
-                  <IconSend size={16} />
-                </ActionIcon>
-              </Group>
-            )}
-          </div>
-        </div>
-
-        <Card.Section className="border-t border-gray-200 p-4">
-          <Text
-            component={Link}
-            href="/board"
-            size="sm"
-            c="dimmed"
-            className="cursor-pointer hover:underline"
-          >
-            게시글 목록보기
-          </Text>
-        </Card.Section>
-      </Card>
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <BoardDetailContents />
+    </HydrationBoundary>
   );
 }

--- a/src/app/board/components/BoardContents.tsx
+++ b/src/app/board/components/BoardContents.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+  Text,
+  Title,
+  Stack,
+  Center,
+  Loader,
+  Alert,
+  ActionIcon,
+  Affix,
+} from '@mantine/core';
+import { IconPlus } from '@tabler/icons-react';
+import { useBoardList, useIncrementBoardViewCount } from '@/services/board/useBoard';
+import { useUser } from '@/services/auth/useUser';
+import { formatTimeSince } from '@/libs/format-date';
+
+export default function BoardContents() {
+  const router = useRouter();
+  const { user } = useUser();
+  const { data: posts, isLoading } = useBoardList();
+  const incrementView = useIncrementBoardViewCount();
+
+  function handleCardClick(postId: number) {
+    incrementView.mutate(postId);
+    router.push(`/board/${postId}`);
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <Stack align="center" gap="xs" className="mb-8">
+        <Text c="dimmed" size="lg">
+          나눔을 통해 행복을 나누다
+        </Text>
+        <Title order={1}>도담덕 정보 나눔</Title>
+      </Stack>
+
+      {isLoading && (
+        <Center className="min-h-[40vh]">
+          <Loader size="lg" />
+        </Center>
+      )}
+
+      {posts && (
+        <Stack gap="md">
+          {posts.map((post) => (
+            <div
+              key={post.id}
+              className="flex cursor-pointer items-center gap-5 rounded-md border border-gray-200 bg-white p-4 transition-all hover:-translate-y-0.5 hover:shadow-lg"
+              onClick={() => handleCardClick(post.id)}
+            >
+              <div className="relative h-32 w-44 shrink-0 overflow-hidden rounded-md">
+                <Image
+                  src={post.image_url || '/images/도담덕로고.png'}
+                  alt={post.title}
+                  fill
+                  className="object-cover"
+                  unoptimized
+                />
+              </div>
+              <div className="flex flex-1 flex-col">
+                <Text fw={600} size="lg" lineClamp={1}>
+                  {post.title}
+                </Text>
+                <Text size="sm" c="dimmed" className="mt-1">
+                  댓글 {post.comment_count}개 · {formatTimeSince(post.created_at)}{' '}
+                  · 조회 {post.views}
+                </Text>
+                <Text size="sm" c="dimmed" className="mt-2" lineClamp={2}>
+                  {post.content}
+                </Text>
+              </div>
+            </div>
+          ))}
+        </Stack>
+      )}
+
+      {posts && posts.length === 0 && (
+        <Alert className="mx-auto max-w-md">게시글이 없습니다.</Alert>
+      )}
+
+      {user && (
+        <Affix position={{ bottom: 40, right: 40 }}>
+          <ActionIcon
+            component={Link}
+            href="/board/new"
+            size={56}
+            radius="xl"
+            variant="filled"
+          >
+            <IconPlus size={24} />
+          </ActionIcon>
+        </Affix>
+      )}
+    </div>
+  );
+}

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -1,101 +1,22 @@
-'use client';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import getQueryClient from '@/libs/query/query-client';
+import { createClient } from '@/libs/supabase/server';
+import { boardQueries } from '@/services/board/queries';
+import { servFetchBoardPosts } from '@/services/board/board-services';
+import BoardContents from './components/BoardContents';
 
-import Image from 'next/image';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import {
-  Text,
-  Title,
-  Stack,
-  Group,
-  Center,
-  Loader,
-  Alert,
-  ActionIcon,
-  Affix,
-} from '@mantine/core';
-import { IconPlus } from '@tabler/icons-react';
-import { useBoardList, useIncrementBoardViewCount } from '@/services/board/useBoard';
-import { useUser } from '@/services/auth/useUser';
-import { formatTimeSince } from '@/libs/format-date';
+export default async function BoardPage() {
+  const queryClient = getQueryClient();
+  const supabase = await createClient();
 
-export default function BoardPage() {
-  const router = useRouter();
-  const { user } = useUser();
-  const { data: posts, isLoading } = useBoardList();
-  const incrementView = useIncrementBoardViewCount();
-
-  function handleCardClick(postId: number) {
-    incrementView.mutate(postId);
-    router.push(`/board/${postId}`);
-  }
+  await queryClient.prefetchQuery({
+    ...boardQueries.all(),
+    queryFn: () => servFetchBoardPosts(supabase),
+  });
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-10">
-      <Stack align="center" gap="xs" className="mb-8">
-        <Text c="dimmed" size="lg">
-          나눔을 통해 행복을 나누다
-        </Text>
-        <Title order={1}>도담덕 정보 나눔</Title>
-      </Stack>
-
-      {isLoading && (
-        <Center className="min-h-[40vh]">
-          <Loader size="lg" />
-        </Center>
-      )}
-
-      {posts && (
-        <Stack gap="md">
-          {posts.map((post) => (
-            <div
-              key={post.id}
-              className="flex cursor-pointer items-center gap-5 rounded-md border border-gray-200 bg-white p-4 transition-all hover:-translate-y-0.5 hover:shadow-lg"
-              onClick={() => handleCardClick(post.id)}
-            >
-              <div className="relative h-32 w-44 shrink-0 overflow-hidden rounded-md">
-                <Image
-                  src={post.image_url || '/images/도담덕로고.png'}
-                  alt={post.title}
-                  fill
-                  className="object-cover"
-                  unoptimized
-                />
-              </div>
-              <div className="flex flex-1 flex-col">
-                <Text fw={600} size="lg" lineClamp={1}>
-                  {post.title}
-                </Text>
-                <Text size="sm" c="dimmed" className="mt-1">
-                  댓글 {post.comment_count}개 · {formatTimeSince(post.created_at)}{' '}
-                  · 조회 {post.views}
-                </Text>
-                <Text size="sm" c="dimmed" className="mt-2" lineClamp={2}>
-                  {post.content}
-                </Text>
-              </div>
-            </div>
-          ))}
-        </Stack>
-      )}
-
-      {posts && posts.length === 0 && (
-        <Alert className="mx-auto max-w-md">게시글이 없습니다.</Alert>
-      )}
-
-      {user && (
-        <Affix position={{ bottom: 40, right: 40 }}>
-          <ActionIcon
-            component={Link}
-            href="/board/new"
-            size={56}
-            radius="xl"
-            variant="filled"
-          >
-            <IconPlus size={24} />
-          </ActionIcon>
-        </Affix>
-      )}
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <BoardContents />
+    </HydrationBoundary>
   );
 }

--- a/src/app/chat/[id]/components/ChatDetailContents.tsx
+++ b/src/app/chat/[id]/components/ChatDetailContents.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import {
+  Text,
+  Stack,
+  Group,
+  Avatar,
+  Badge,
+  TextInput,
+  ActionIcon,
+  Center,
+  ScrollArea,
+} from '@mantine/core';
+import { IconSend, IconMessageCircle } from '@tabler/icons-react';
+import { useChatList, useChatMessages, useSendMessage } from '@/services/chat/useChat';
+import type { User } from '@supabase/supabase-js';
+import type { Profile } from '@/services/auth/auth.types';
+
+interface ChatDetailContentsProps {
+  user: User;
+  profile: Profile;
+}
+
+export default function ChatDetailContents({ user, profile }: ChatDetailContentsProps) {
+  const { id } = useParams<{ id: string }>();
+  const roomId = Number(id);
+  const [message, setMessage] = useState('');
+  const viewport = useRef<HTMLDivElement>(null);
+
+  const { data: chatList } = useChatList();
+  const { data: messages } = useChatMessages(roomId);
+  const sendMessage = useSendMessage();
+
+  const rooms = chatList ?? [];
+
+  const currentRoom = rooms.find((r) => r.id === roomId);
+  const isUser1 = currentRoom?.user1_id === user.id;
+  const partnerProfile = currentRoom
+    ? isUser1
+      ? currentRoom.user2_profile
+      : currentRoom.user1_profile
+    : null;
+
+  useEffect(() => {
+    if (viewport.current) {
+      viewport.current.scrollTo({
+        top: viewport.current.scrollHeight,
+        behavior: 'smooth',
+      });
+    }
+  }, [messages]);
+
+  function handleSend() {
+    if (!message.trim() || roomId <= 0) return;
+    sendMessage.mutate(
+      { roomId, message },
+      { onSuccess: () => setMessage('') }
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <div className="flex flex-col gap-6 md:flex-row">
+        <div className="w-full md:w-80">
+          <Stack align="center" className="mb-6 rounded-md border border-gray-200 bg-white p-4">
+            <Avatar
+              src={profile.profile_url || undefined}
+              size={80}
+              radius="xl"
+            />
+            <Text fw={600}>{profile.display_name}</Text>
+            <Badge variant="light">level.{profile.level}</Badge>
+          </Stack>
+
+          <Text fw={600} size="sm" className="mb-3">
+            채팅 중인 이웃
+          </Text>
+
+          <Stack gap="xs">
+            {rooms.map((chat) => {
+              const chatIsUser1 = chat.user1_id === user.id;
+              const pProfile = chatIsUser1
+                ? chat.user2_profile
+                : chat.user1_profile;
+              const isActive = chat.id === roomId;
+
+              return (
+                <Link
+                  key={chat.id}
+                  href={`/chat/${chat.id}`}
+                  className="no-underline"
+                >
+                  <Group
+                    className={`cursor-pointer rounded-md border p-3 transition-colors ${
+                      isActive
+                        ? 'border-dodam-yellow bg-dodam-light'
+                        : 'border-gray-200 bg-white hover:bg-gray-50'
+                    }`}
+                    wrap="nowrap"
+                  >
+                    <Avatar
+                      src={pProfile.profile_url || undefined}
+                      size="md"
+                      radius="xl"
+                    />
+                    <Stack gap={2} className="min-w-0 flex-1">
+                      <Text size="sm" fw={600} truncate>
+                        {pProfile.display_name}
+                      </Text>
+                      <Text size="xs" c="dimmed" truncate>
+                        {chat.last_message}
+                      </Text>
+                    </Stack>
+                  </Group>
+                </Link>
+              );
+            })}
+          </Stack>
+        </div>
+
+        <div className="flex flex-1 flex-col rounded-md border border-gray-200 bg-white">
+          <Group className="border-b border-gray-200 p-4">
+            <Avatar
+              src={partnerProfile?.profile_url || undefined}
+              size="md"
+              radius="xl"
+            />
+            <Text fw={600}>{partnerProfile?.display_name ?? ''}</Text>
+          </Group>
+
+          <ScrollArea
+            viewportRef={viewport}
+            className="scrollbar-brand flex-1 p-4"
+            h={400}
+          >
+            <Stack gap="sm">
+              {messages?.map((msg) => {
+                const isMe = msg.sender_id === user.id;
+                return (
+                  <div
+                    key={msg.id}
+                    className={`flex ${isMe ? 'justify-end' : 'justify-start'}`}
+                  >
+                    {!isMe && <Avatar size="sm" radius="xl" className="mr-2" />}
+                    <div
+                      className={`max-w-[70%] px-4 py-2 ${
+                        isMe
+                          ? 'chat-bubble-me bg-dodam-yellow text-white'
+                          : 'chat-bubble-partner bg-gray-100 text-gray-800'
+                      }`}
+                    >
+                      <Text size="sm">{msg.message}</Text>
+                    </div>
+                  </div>
+                );
+              })}
+              {(!messages || messages.length === 0) && (
+                <Center className="py-10">
+                  <Stack align="center" gap="xs">
+                    <IconMessageCircle size={40} color="#d6d6d6" />
+                    <Text c="dimmed" size="sm">
+                      대화를 시작해보세요
+                    </Text>
+                  </Stack>
+                </Center>
+              )}
+            </Stack>
+          </ScrollArea>
+
+          <Group className="border-t border-gray-200 p-3" wrap="nowrap">
+            <TextInput
+              placeholder="메시지를 입력하세요"
+              value={message}
+              onChange={(e) => setMessage(e.currentTarget.value)}
+              className="flex-1"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSend();
+              }}
+            />
+            <ActionIcon
+              onClick={handleSend}
+              loading={sendMessage.isPending}
+              variant="filled"
+            >
+              <IconSend size={16} />
+            </ActionIcon>
+          </Group>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -1,208 +1,53 @@
-'use client';
+import { redirect } from 'next/navigation';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import getQueryClient from '@/libs/query/query-client';
+import { createClient } from '@/libs/supabase/server';
+import { chatQueries } from '@/services/chat/queries';
+import { servFetchChatList, servFetchMessages } from '@/services/chat/chat-services';
+import type { Profile } from '@/services/auth/auth.types';
+import ChatDetailContents from './components/ChatDetailContents';
 
-import { useState, useRef, useEffect } from 'react';
-import { useParams } from 'next/navigation';
-import Link from 'next/link';
-import {
-  Text,
-  Stack,
-  Group,
-  Avatar,
-  Badge,
-  TextInput,
-  ActionIcon,
-  Center,
-  Loader,
-  ScrollArea,
-} from '@mantine/core';
-import { IconSend, IconMessageCircle } from '@tabler/icons-react';
-import { useChatList, useChatMessages, useSendMessage } from '@/services/chat/useChat';
-import { useUser } from '@/services/auth/useUser';
-import { AuthGuard } from '@/components/common/AuthGuard';
-
-export default function ChatDetailPage() {
-  return (
-    <AuthGuard>
-      <ChatDetailContent />
-    </AuthGuard>
-  );
+interface ChatDetailPageProps {
+  params: Promise<{ id: string }>;
 }
 
-function ChatDetailContent() {
-  const { id } = useParams<{ id: string }>();
+export default async function ChatDetailPage({
+  params,
+}: ChatDetailPageProps) {
+  const { id } = await params;
   const roomId = Number(id);
-  const { user, profile, isLoading: isUserLoading } = useUser();
-  const [message, setMessage] = useState('');
-  const viewport = useRef<HTMLDivElement>(null);
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  const { data: chatList } = useChatList();
-  const { data: messages } = useChatMessages(roomId);
-  const sendMessage = useSendMessage();
-
-  const rooms = chatList ?? [];
-
-  const currentRoom = rooms.find((r) => r.id === roomId);
-  const isUser1 = currentRoom?.user1_id === user?.id;
-  const partnerProfile = currentRoom
-    ? isUser1
-      ? currentRoom.user2_profile
-      : currentRoom.user1_profile
-    : null;
-
-  useEffect(() => {
-    if (viewport.current) {
-      viewport.current.scrollTo({
-        top: viewport.current.scrollHeight,
-        behavior: 'smooth',
-      });
-    }
-  }, [messages]);
-
-  function handleSend() {
-    if (!message.trim() || !user || roomId <= 0) return;
-    sendMessage.mutate(
-      { roomId, message },
-      { onSuccess: () => setMessage('') }
-    );
+  if (!user) {
+    redirect(`/login?callbackUrl=/chat/${id}`);
   }
 
-  if (isUserLoading || !user || !profile) {
-    return (
-      <Center className="min-h-[60vh]">
-        <Loader size="lg" />
-      </Center>
-    );
-  }
+  const queryClient = getQueryClient();
+
+  const [, { data: profile }] = await Promise.all([
+    Promise.all([
+      queryClient.prefetchQuery({
+        ...chatQueries.list(),
+        queryFn: () => servFetchChatList(supabase),
+      }),
+      queryClient.prefetchQuery({
+        ...chatQueries.messages(roomId),
+        queryFn: () => servFetchMessages(roomId, supabase),
+      }),
+    ]),
+    supabase
+      .from('profiles')
+      .select('*')
+      .eq('id', user.id)
+      .single<Profile>(),
+  ]);
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-10">
-      <div className="flex flex-col gap-6 md:flex-row">
-        <div className="w-full md:w-80">
-          <Stack align="center" className="mb-6 rounded-md border border-gray-200 bg-white p-4">
-            <Avatar
-              src={profile.profile_url || undefined}
-              size={80}
-              radius="xl"
-            />
-            <Text fw={600}>{profile.display_name}</Text>
-            <Badge variant="light">level.{profile.level}</Badge>
-          </Stack>
-
-          <Text fw={600} size="sm" className="mb-3">
-            채팅 중인 이웃
-          </Text>
-
-          <Stack gap="xs">
-            {rooms.map((chat) => {
-              const chatIsUser1 = chat.user1_id === user.id;
-              const pProfile = chatIsUser1
-                ? chat.user2_profile
-                : chat.user1_profile;
-              const isActive = chat.id === roomId;
-
-              return (
-                <Link
-                  key={chat.id}
-                  href={`/chat/${chat.id}`}
-                  className="no-underline"
-                >
-                  <Group
-                    className={`cursor-pointer rounded-md border p-3 transition-colors ${
-                      isActive
-                        ? 'border-dodam-yellow bg-dodam-light'
-                        : 'border-gray-200 bg-white hover:bg-gray-50'
-                    }`}
-                    wrap="nowrap"
-                  >
-                    <Avatar
-                      src={pProfile.profile_url || undefined}
-                      size="md"
-                      radius="xl"
-                    />
-                    <Stack gap={2} className="min-w-0 flex-1">
-                      <Text size="sm" fw={600} truncate>
-                        {pProfile.display_name}
-                      </Text>
-                      <Text size="xs" c="dimmed" truncate>
-                        {chat.last_message}
-                      </Text>
-                    </Stack>
-                  </Group>
-                </Link>
-              );
-            })}
-          </Stack>
-        </div>
-
-        <div className="flex flex-1 flex-col rounded-md border border-gray-200 bg-white">
-          <Group className="border-b border-gray-200 p-4">
-            <Avatar
-              src={partnerProfile?.profile_url || undefined}
-              size="md"
-              radius="xl"
-            />
-            <Text fw={600}>{partnerProfile?.display_name ?? ''}</Text>
-          </Group>
-
-          <ScrollArea
-            viewportRef={viewport}
-            className="scrollbar-brand flex-1 p-4"
-            h={400}
-          >
-            <Stack gap="sm">
-              {messages?.map((msg) => {
-                const isMe = msg.sender_id === user.id;
-                return (
-                  <div
-                    key={msg.id}
-                    className={`flex ${isMe ? 'justify-end' : 'justify-start'}`}
-                  >
-                    {!isMe && <Avatar size="sm" radius="xl" className="mr-2" />}
-                    <div
-                      className={`max-w-[70%] px-4 py-2 ${
-                        isMe
-                          ? 'chat-bubble-me bg-dodam-yellow text-white'
-                          : 'chat-bubble-partner bg-gray-100 text-gray-800'
-                      }`}
-                    >
-                      <Text size="sm">{msg.message}</Text>
-                    </div>
-                  </div>
-                );
-              })}
-              {(!messages || messages.length === 0) && (
-                <Center className="py-10">
-                  <Stack align="center" gap="xs">
-                    <IconMessageCircle size={40} color="#d6d6d6" />
-                    <Text c="dimmed" size="sm">
-                      대화를 시작해보세요
-                    </Text>
-                  </Stack>
-                </Center>
-              )}
-            </Stack>
-          </ScrollArea>
-
-          <Group className="border-t border-gray-200 p-3" wrap="nowrap">
-            <TextInput
-              placeholder="메시지를 입력하세요"
-              value={message}
-              onChange={(e) => setMessage(e.currentTarget.value)}
-              className="flex-1"
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleSend();
-              }}
-            />
-            <ActionIcon
-              onClick={handleSend}
-              loading={sendMessage.isPending}
-              variant="filled"
-            >
-              <IconSend size={16} />
-            </ActionIcon>
-          </Group>
-        </div>
-      </div>
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ChatDetailContents user={user} profile={profile!} />
+    </HydrationBoundary>
   );
 }

--- a/src/app/chat/components/ChatContents.tsx
+++ b/src/app/chat/components/ChatContents.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  Text,
+  Stack,
+  Group,
+  Avatar,
+  Badge,
+  Center,
+  Loader,
+} from '@mantine/core';
+import { IconMessageCircle } from '@tabler/icons-react';
+import { useChatList } from '@/services/chat/useChat';
+import type { User } from '@supabase/supabase-js';
+import type { Profile } from '@/services/auth/auth.types';
+
+interface ChatContentsProps {
+  user: User;
+  profile: Profile;
+}
+
+export default function ChatContents({ user, profile }: ChatContentsProps) {
+  const { data: chatList, isLoading } = useChatList();
+
+  const rooms = chatList ?? [];
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <div className="flex flex-col gap-6 md:flex-row">
+        <div className="w-full md:w-80">
+          <Stack align="center" className="mb-6 rounded-md border border-gray-200 bg-white p-4">
+            <Avatar
+              src={profile.profile_url || undefined}
+              size={80}
+              radius="xl"
+            />
+            <Text fw={600}>{profile.display_name}</Text>
+            <Badge variant="light">level.{profile.level}</Badge>
+          </Stack>
+
+          <Text fw={600} size="sm" className="mb-3">
+            채팅 중인 이웃
+          </Text>
+
+          {isLoading && (
+            <Center className="min-h-[20vh]">
+              <Loader size="sm" />
+            </Center>
+          )}
+
+          <Stack gap="xs">
+            {rooms.map((chat) => {
+              const isUser1 = chat.user1_id === user.id;
+              const partnerProfile = isUser1
+                ? chat.user2_profile
+                : chat.user1_profile;
+
+              return (
+                <Link
+                  key={chat.id}
+                  href={`/chat/${chat.id}`}
+                  className="no-underline"
+                >
+                  <Group
+                    className="cursor-pointer rounded-md border border-gray-200 bg-white p-3 transition-colors hover:bg-gray-50"
+                    wrap="nowrap"
+                  >
+                    <Avatar
+                      src={partnerProfile.profile_url || undefined}
+                      size="md"
+                      radius="xl"
+                    />
+                    <Stack gap={2} className="min-w-0 flex-1">
+                      <Text size="sm" fw={600} truncate>
+                        {partnerProfile.display_name}
+                      </Text>
+                      <Text size="xs" c="dimmed" truncate>
+                        {chat.last_message}
+                      </Text>
+                    </Stack>
+                  </Group>
+                </Link>
+              );
+            })}
+
+            {!isLoading && rooms.length === 0 && (
+              <Text c="dimmed" size="sm" className="text-center">
+                채팅 목록이 없습니다.
+              </Text>
+            )}
+          </Stack>
+        </div>
+
+        <div className="flex flex-1 flex-col items-center justify-center rounded-md border border-gray-200 bg-white p-10">
+          <IconMessageCircle size={80} color="#d6d6d6" />
+          <Text c="dimmed" className="mt-4">
+            채팅할 상대를 선택해주세요
+          </Text>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,117 +1,39 @@
-'use client';
+import { redirect } from 'next/navigation';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import getQueryClient from '@/libs/query/query-client';
+import { createClient } from '@/libs/supabase/server';
+import { chatQueries } from '@/services/chat/queries';
+import { servFetchChatList } from '@/services/chat/chat-services';
+import type { Profile } from '@/services/auth/auth.types';
+import ChatContents from './components/ChatContents';
 
-import Link from 'next/link';
-import {
-  Text,
-  Title,
-  Stack,
-  Group,
-  Avatar,
-  Badge,
-  Center,
-  Loader,
-} from '@mantine/core';
-import { IconMessageCircle } from '@tabler/icons-react';
-import { useChatList } from '@/services/chat/useChat';
-import { useUser } from '@/services/auth/useUser';
-import { AuthGuard } from '@/components/common/AuthGuard';
+export default async function ChatPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-export default function ChatPage() {
-  return (
-    <AuthGuard>
-      <ChatContent />
-    </AuthGuard>
-  );
-}
-
-function ChatContent() {
-  const { user, profile, isLoading: isUserLoading } = useUser();
-  const { data: chatList, isLoading } = useChatList();
-
-  if (isUserLoading || !user || !profile) {
-    return (
-      <Center className="min-h-[60vh]">
-        <Loader size="lg" />
-      </Center>
-    );
+  if (!user) {
+    redirect('/login?callbackUrl=/chat');
   }
 
-  const rooms = chatList ?? [];
+  const [queryClient, { data: profile }] = await Promise.all([
+    Promise.resolve(getQueryClient()),
+    supabase
+      .from('profiles')
+      .select('*')
+      .eq('id', user.id)
+      .single<Profile>(),
+  ]);
+
+  await queryClient.prefetchQuery({
+    ...chatQueries.list(),
+    queryFn: () => servFetchChatList(supabase),
+  });
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-10">
-      <div className="flex flex-col gap-6 md:flex-row">
-        <div className="w-full md:w-80">
-          <Stack align="center" className="mb-6 rounded-md border border-gray-200 bg-white p-4">
-            <Avatar
-              src={profile.profile_url || undefined}
-              size={80}
-              radius="xl"
-            />
-            <Text fw={600}>{profile.display_name}</Text>
-            <Badge variant="light">level.{profile.level}</Badge>
-          </Stack>
-
-          <Text fw={600} size="sm" className="mb-3">
-            채팅 중인 이웃
-          </Text>
-
-          {isLoading && (
-            <Center className="min-h-[20vh]">
-              <Loader size="sm" />
-            </Center>
-          )}
-
-          <Stack gap="xs">
-            {rooms.map((chat) => {
-              const isUser1 = chat.user1_id === user.id;
-              const partnerProfile = isUser1
-                ? chat.user2_profile
-                : chat.user1_profile;
-
-              return (
-                <Link
-                  key={chat.id}
-                  href={`/chat/${chat.id}`}
-                  className="no-underline"
-                >
-                  <Group
-                    className="cursor-pointer rounded-md border border-gray-200 bg-white p-3 transition-colors hover:bg-gray-50"
-                    wrap="nowrap"
-                  >
-                    <Avatar
-                      src={partnerProfile.profile_url || undefined}
-                      size="md"
-                      radius="xl"
-                    />
-                    <Stack gap={2} className="min-w-0 flex-1">
-                      <Text size="sm" fw={600} truncate>
-                        {partnerProfile.display_name}
-                      </Text>
-                      <Text size="xs" c="dimmed" truncate>
-                        {chat.last_message}
-                      </Text>
-                    </Stack>
-                  </Group>
-                </Link>
-              );
-            })}
-
-            {!isLoading && rooms.length === 0 && (
-              <Text c="dimmed" size="sm" className="text-center">
-                채팅 목록이 없습니다.
-              </Text>
-            )}
-          </Stack>
-        </div>
-
-        <div className="flex flex-1 flex-col items-center justify-center rounded-md border border-gray-200 bg-white p-10">
-          <IconMessageCircle size={80} color="#d6d6d6" />
-          <Text c="dimmed" className="mt-4">
-            채팅할 상대를 선택해주세요
-          </Text>
-        </div>
-      </div>
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ChatContents user={user} profile={profile!} />
+    </HydrationBoundary>
   );
 }

--- a/src/app/library/components/LibraryContents.tsx
+++ b/src/app/library/components/LibraryContents.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Center,
+  Loader,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+  Alert,
+} from '@mantine/core';
+import { IconPhone } from '@tabler/icons-react';
+
+import { useLibraryItems } from '@/services/library/useLibrary';
+import { getCategoryConfig } from '@/services/library/library-services';
+import type { LibraryItem } from '@/services/library/library.types';
+
+function ToyCard({ item }: { item: LibraryItem }) {
+  const config = getCategoryConfig(item['영 역']);
+  const Icon = config.icon;
+
+  return (
+    <Card
+      shadow="sm"
+      padding={0}
+      radius="md"
+      withBorder
+      className="transition-all hover:-translate-y-1 hover:shadow-lg"
+    >
+      <Card.Section>
+        <Box
+          className="flex items-center justify-center"
+          style={{ background: config.gradient, height: 140 }}
+        >
+          <Icon size={56} color="white" stroke={1.5} />
+        </Box>
+      </Card.Section>
+
+      <Stack gap="xs" className="p-4">
+        <Text fw={600} size="md" lineClamp={1}>
+          {item.장난감명}
+        </Text>
+
+        <Badge color={config.color} variant="light" size="sm" className="w-fit">
+          {item['영 역']}
+        </Badge>
+
+        <Stack gap={4}>
+          <Text size="sm" c="dimmed">
+            사용연령: {item.사용연령}
+          </Text>
+          <Text size="sm" c="dimmed">
+            대여료: {item.대여료}
+          </Text>
+          {item.제조사 && (
+            <Text size="sm" c="dimmed">
+              제조사: {item.제조사}
+            </Text>
+          )}
+        </Stack>
+
+        {item.관리기관전화번호 ? (
+          <Button
+            component="a"
+            href={`tel:${item.관리기관전화번호}`}
+            variant="outline"
+            fullWidth
+            size="sm"
+            leftSection={<IconPhone size={16} />}
+          >
+            대여 문의
+          </Button>
+        ) : (
+          <Button variant="outline" fullWidth size="sm" disabled>
+            대여 문의
+          </Button>
+        )}
+      </Stack>
+    </Card>
+  );
+}
+
+export default function LibraryContents() {
+  const { data: items, isLoading, error } = useLibraryItems();
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10">
+      <Stack align="center" gap="xs" className="mb-10">
+        <Text c="dimmed" size="lg">
+          원하는 장난감을 빌릴 수 있는
+        </Text>
+        <Title order={1}>장난감 도서관</Title>
+      </Stack>
+
+      {isLoading && (
+        <Center className="min-h-[40vh]">
+          <Loader size="lg" />
+        </Center>
+      )}
+
+      {error && (
+        <Alert color="red" className="mx-auto max-w-md">
+          장난감 목록을 불러오는 데 실패했습니다.
+        </Alert>
+      )}
+
+      {items && (
+        <SimpleGrid cols={{ base: 1, xs: 2, sm: 3, md: 4 }} spacing="lg">
+          {items.map((item) => (
+            <ToyCard key={item.순번} item={item} />
+          ))}
+        </SimpleGrid>
+      )}
+    </div>
+  );
+}

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -1,120 +1,20 @@
-'use client';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import getQueryClient from '@/libs/query/query-client';
+import { libraryQueries } from '@/services/library/queries';
+import { servFetchLibraryItemsServer } from '@/services/library/library-services';
+import LibraryContents from './components/LibraryContents';
 
-import {
-  Badge,
-  Box,
-  Button,
-  Card,
-  Center,
-  Loader,
-  SimpleGrid,
-  Stack,
-  Text,
-  Title,
-  Alert,
-} from '@mantine/core';
-import { IconPhone } from '@tabler/icons-react';
+export default async function LibraryPage() {
+  const queryClient = getQueryClient();
 
-import { useLibraryItems } from '@/services/library/useLibrary';
-import { getCategoryConfig } from '@/services/library/library-services';
-import type { LibraryItem } from '@/services/library/library.types';
-
-function ToyCard({ item }: { item: LibraryItem }) {
-  const config = getCategoryConfig(item['영 역']);
-  const Icon = config.icon;
+  await queryClient.prefetchQuery({
+    ...libraryQueries.all(),
+    queryFn: () => servFetchLibraryItemsServer(),
+  });
 
   return (
-    <Card
-      shadow="sm"
-      padding={0}
-      radius="md"
-      withBorder
-      className="transition-all hover:-translate-y-1 hover:shadow-lg"
-    >
-      <Card.Section>
-        <Box
-          className="flex items-center justify-center"
-          style={{ background: config.gradient, height: 140 }}
-        >
-          <Icon size={56} color="white" stroke={1.5} />
-        </Box>
-      </Card.Section>
-
-      <Stack gap="xs" className="p-4">
-        <Text fw={600} size="md" lineClamp={1}>
-          {item.장난감명}
-        </Text>
-
-        <Badge color={config.color} variant="light" size="sm" className="w-fit">
-          {item['영 역']}
-        </Badge>
-
-        <Stack gap={4}>
-          <Text size="sm" c="dimmed">
-            사용연령: {item.사용연령}
-          </Text>
-          <Text size="sm" c="dimmed">
-            대여료: {item.대여료}
-          </Text>
-          {item.제조사 && (
-            <Text size="sm" c="dimmed">
-              제조사: {item.제조사}
-            </Text>
-          )}
-        </Stack>
-
-        {item.관리기관전화번호 ? (
-          <Button
-            component="a"
-            href={`tel:${item.관리기관전화번호}`}
-            variant="outline"
-            fullWidth
-            size="sm"
-            leftSection={<IconPhone size={16} />}
-          >
-            대여 문의
-          </Button>
-        ) : (
-          <Button variant="outline" fullWidth size="sm" disabled>
-            대여 문의
-          </Button>
-        )}
-      </Stack>
-    </Card>
-  );
-}
-
-export default function LibraryPage() {
-  const { data: items, isLoading, error } = useLibraryItems();
-
-  return (
-    <div className="mx-auto max-w-6xl px-4 py-10">
-      <Stack align="center" gap="xs" className="mb-10">
-        <Text c="dimmed" size="lg">
-          원하는 장난감을 빌릴 수 있는
-        </Text>
-        <Title order={1}>장난감 도서관</Title>
-      </Stack>
-
-      {isLoading && (
-        <Center className="min-h-[40vh]">
-          <Loader size="lg" />
-        </Center>
-      )}
-
-      {error && (
-        <Alert color="red" className="mx-auto max-w-md">
-          장난감 목록을 불러오는 데 실패했습니다.
-        </Alert>
-      )}
-
-      {items && (
-        <SimpleGrid cols={{ base: 1, xs: 2, sm: 3, md: 4 }} spacing="lg">
-          {items.map((item) => (
-            <ToyCard key={item.순번} item={item} />
-          ))}
-        </SimpleGrid>
-      )}
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <LibraryContents />
+    </HydrationBoundary>
   );
 }

--- a/src/app/my-shop/components/MyShopContents.tsx
+++ b/src/app/my-shop/components/MyShopContents.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import {
+  Card,
+  Text,
+  Title,
+  Stack,
+  Group,
+  Avatar,
+  Badge,
+  SimpleGrid,
+  Tabs,
+  Center,
+  Loader,
+} from '@mantine/core';
+import { useSharingList, useIncrementSharingViewCount } from '@/services/sharing/useSharing';
+import type { User } from '@supabase/supabase-js';
+import type { Profile } from '@/services/auth/auth.types';
+
+interface MyShopContentsProps {
+  user: User;
+  profile: Profile;
+}
+
+export default function MyShopContents({ user, profile }: MyShopContentsProps) {
+  const router = useRouter();
+  const { data: allPosts, isLoading } = useSharingList();
+  const incrementView = useIncrementSharingViewCount();
+
+  const myPosts = allPosts?.filter((post) => post.user_id === user.id);
+
+  function handleProductClick(postId: number) {
+    incrementView.mutate(postId);
+    router.push(`/sharing/${postId}`);
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <Card shadow="sm" padding="xl" radius="md" withBorder className="mb-8">
+        <Group>
+          <Avatar
+            src={profile.profile_url || undefined}
+            size={120}
+            radius="xl"
+          />
+          <Stack gap="xs">
+            <Title order={3}>
+              {profile.display_name}({profile.username}) 님
+            </Title>
+            <Badge variant="light">level.{profile.level}</Badge>
+            <Text size="sm" c="dimmed">
+              인증 횟수: {profile.verification_count}
+            </Text>
+            <Text size="sm" c="dimmed">
+              위치: {profile.location}
+            </Text>
+          </Stack>
+        </Group>
+      </Card>
+
+      <Tabs defaultValue="products">
+        <Tabs.List>
+          <Tabs.Tab value="products">상품</Tabs.Tab>
+          <Tabs.Tab value="wishlist">하트목록</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="products" className="pt-6">
+          {isLoading && (
+            <Center className="min-h-[20vh]">
+              <Loader size="md" />
+            </Center>
+          )}
+
+          {myPosts && myPosts.length > 0 ? (
+            <SimpleGrid cols={{ base: 2, sm: 3, md: 4 }} spacing="md">
+              {myPosts.map((post) => (
+                <div
+                  key={post.id}
+                  className="cursor-pointer"
+                  onClick={() => handleProductClick(post.id)}
+                >
+                  <div className="relative aspect-square overflow-hidden rounded-md">
+                    <Image
+                      src={post.image_url || '/images/도담덕로고.png'}
+                      alt={post.title}
+                      fill
+                      className="object-cover"
+                      unoptimized
+                    />
+                  </div>
+                  <Text size="sm" className="mt-2" lineClamp={1}>
+                    {post.title}
+                  </Text>
+                </div>
+              ))}
+            </SimpleGrid>
+          ) : (
+            !isLoading && (
+              <Text c="dimmed" className="text-center">
+                등록한 상품이 없습니다.
+              </Text>
+            )
+          )}
+        </Tabs.Panel>
+
+        <Tabs.Panel value="wishlist" className="pt-6">
+          <Text c="dimmed" className="text-center">
+            준비중입니다.
+          </Text>
+        </Tabs.Panel>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/my-shop/page.tsx
+++ b/src/app/my-shop/page.tsx
@@ -1,128 +1,39 @@
-'use client';
+import { redirect } from 'next/navigation';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import getQueryClient from '@/libs/query/query-client';
+import { createClient } from '@/libs/supabase/server';
+import { sharingQueries } from '@/services/sharing/queries';
+import { servFetchSharingPosts } from '@/services/sharing/sharing-services';
+import type { Profile } from '@/services/auth/auth.types';
+import MyShopContents from './components/MyShopContents';
 
-import Image from 'next/image';
-import { useRouter } from 'next/navigation';
-import {
-  Card,
-  Text,
-  Title,
-  Stack,
-  Group,
-  Avatar,
-  Badge,
-  SimpleGrid,
-  Tabs,
-  Center,
-  Loader,
-} from '@mantine/core';
-import { useSharingList, useIncrementSharingViewCount } from '@/services/sharing/useSharing';
-import { useUser } from '@/services/auth/useUser';
-import { AuthGuard } from '@/components/common/AuthGuard';
+export default async function MyShopPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-export default function MyShopPage() {
-  return (
-    <AuthGuard>
-      <MyShopContent />
-    </AuthGuard>
-  );
-}
-
-function MyShopContent() {
-  const router = useRouter();
-  const { user, profile, isLoading: isUserLoading } = useUser();
-  const { data: allPosts, isLoading } = useSharingList();
-  const incrementView = useIncrementSharingViewCount();
-
-  const myPosts = allPosts?.filter((post) => post.user_id === user?.id);
-
-  function handleProductClick(postId: number) {
-    incrementView.mutate(postId);
-    router.push(`/sharing/${postId}`);
+  if (!user) {
+    redirect('/login?callbackUrl=/my-shop');
   }
 
-  if (isUserLoading || !user || !profile) {
-    return (
-      <Center className="min-h-[60vh]">
-        <Loader size="lg" />
-      </Center>
-    );
-  }
+  const queryClient = getQueryClient();
+
+  const [, { data: profile }] = await Promise.all([
+    queryClient.prefetchQuery({
+      ...sharingQueries.all(),
+      queryFn: () => servFetchSharingPosts(supabase),
+    }),
+    supabase
+      .from('profiles')
+      .select('*')
+      .eq('id', user.id)
+      .single<Profile>(),
+  ]);
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-10">
-      <Card shadow="sm" padding="xl" radius="md" withBorder className="mb-8">
-        <Group>
-          <Avatar
-            src={profile.profile_url || undefined}
-            size={120}
-            radius="xl"
-          />
-          <Stack gap="xs">
-            <Title order={3}>
-              {profile.display_name}({profile.username}) 님
-            </Title>
-            <Badge variant="light">level.{profile.level}</Badge>
-            <Text size="sm" c="dimmed">
-              인증 횟수: {profile.verification_count}
-            </Text>
-            <Text size="sm" c="dimmed">
-              위치: {profile.location}
-            </Text>
-          </Stack>
-        </Group>
-      </Card>
-
-      <Tabs defaultValue="products">
-        <Tabs.List>
-          <Tabs.Tab value="products">상품</Tabs.Tab>
-          <Tabs.Tab value="wishlist">하트목록</Tabs.Tab>
-        </Tabs.List>
-
-        <Tabs.Panel value="products" className="pt-6">
-          {isLoading && (
-            <Center className="min-h-[20vh]">
-              <Loader size="md" />
-            </Center>
-          )}
-
-          {myPosts && myPosts.length > 0 ? (
-            <SimpleGrid cols={{ base: 2, sm: 3, md: 4 }} spacing="md">
-              {myPosts.map((post) => (
-                <div
-                  key={post.id}
-                  className="cursor-pointer"
-                  onClick={() => handleProductClick(post.id)}
-                >
-                  <div className="relative aspect-square overflow-hidden rounded-md">
-                    <Image
-                      src={post.image_url || '/images/도담덕로고.png'}
-                      alt={post.title}
-                      fill
-                      className="object-cover"
-                      unoptimized
-                    />
-                  </div>
-                  <Text size="sm" className="mt-2" lineClamp={1}>
-                    {post.title}
-                  </Text>
-                </div>
-              ))}
-            </SimpleGrid>
-          ) : (
-            !isLoading && (
-              <Text c="dimmed" className="text-center">
-                등록한 상품이 없습니다.
-              </Text>
-            )
-          )}
-        </Tabs.Panel>
-
-        <Tabs.Panel value="wishlist" className="pt-6">
-          <Text c="dimmed" className="text-center">
-            준비중입니다.
-          </Text>
-        </Tabs.Panel>
-      </Tabs>
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <MyShopContents user={user} profile={profile!} />
+    </HydrationBoundary>
   );
 }

--- a/src/app/sharing/[id]/components/SharingDetailContents.tsx
+++ b/src/app/sharing/[id]/components/SharingDetailContents.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Image from 'next/image';
+import Link from 'next/link';
+import {
+  Card,
+  Text,
+  Title,
+  Stack,
+  Group,
+  Avatar,
+  Button,
+  TextInput,
+  Divider,
+  Center,
+  Loader,
+  Alert,
+  ActionIcon,
+  ScrollArea,
+} from '@mantine/core';
+import { IconTrash, IconMessageCircle, IconSend } from '@tabler/icons-react';
+import {
+  useSharingDetail,
+  useDeleteSharingPost,
+  useAddSharingComment,
+} from '@/services/sharing/useSharing';
+import { useCreateChatRoom } from '@/services/chat/useChat';
+import { useUser } from '@/services/auth/useUser';
+
+export default function SharingDetailContents() {
+  const { id } = useParams<{ id: string }>();
+  const postId = Number(id);
+  const router = useRouter();
+  const { user } = useUser();
+  const [comment, setComment] = useState('');
+
+  const { data, isLoading } = useSharingDetail(postId);
+  const deleteMutation = useDeleteSharingPost();
+  const commentMutation = useAddSharingComment();
+  const createChatRoom = useCreateChatRoom();
+
+  if (isLoading) {
+    return (
+      <Center className="min-h-[60vh]">
+        <Loader size="lg" />
+      </Center>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Alert color="red" className="mx-auto mt-10 max-w-md">
+        게시글을 찾을 수 없습니다.
+      </Alert>
+    );
+  }
+
+  const { post, comments } = data;
+  const isAuthor = user?.id === post.user_id;
+
+  function handleDelete() {
+    if (!user) return;
+    deleteMutation.mutate(postId, {
+      onSuccess: () => router.push('/sharing'),
+    });
+  }
+
+  function handleComment() {
+    if (!comment.trim() || !user) return;
+    commentMutation.mutate(
+      { postId, content: comment },
+      { onSuccess: () => setComment('') }
+    );
+  }
+
+  function handleChat() {
+    if (!user) return;
+    createChatRoom.mutate(
+      { postId, otherUserId: post.user_id },
+      { onSuccess: () => router.push('/chat') }
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <Card shadow="sm" radius="md" withBorder>
+        <Card.Section className="border-b border-gray-200 p-4">
+          <Text fw={600}>교환 &amp; 나눔 게시판</Text>
+        </Card.Section>
+
+        <div className="flex flex-col gap-6 p-6 md:flex-row">
+          <div className="flex flex-col gap-4 md:w-1/2">
+            <div className="relative aspect-square overflow-hidden rounded-md">
+              <Image
+                src={post.image_url || '/images/도담덕로고.png'}
+                alt={post.title}
+                fill
+                className="object-cover"
+                unoptimized
+              />
+            </div>
+
+            <Group>
+              <Avatar
+                src={post.profiles.profile_url || undefined}
+                size="lg"
+                radius="xl"
+              />
+              <Stack gap={2}>
+                <Text fw={600}>{post.profiles.display_name} 님</Text>
+                <Text size="xs" c="dimmed">
+                  {post.location}
+                </Text>
+                <Text size="xs" c="dimmed">
+                  {post.created_at}
+                </Text>
+              </Stack>
+            </Group>
+
+            {user && !isAuthor && (
+              <Button
+                leftSection={<IconMessageCircle size={16} />}
+                onClick={handleChat}
+                loading={createChatRoom.isPending}
+              >
+                채팅하기
+              </Button>
+            )}
+          </div>
+
+          <Divider orientation="vertical" className="hidden md:block" />
+
+          <div className="flex flex-1 flex-col">
+            <Group justify="space-between">
+              <Title order={3}>{post.title}</Title>
+              {isAuthor && (
+                <ActionIcon
+                  variant="subtle"
+                  color="red"
+                  onClick={handleDelete}
+                  loading={deleteMutation.isPending}
+                >
+                  <IconTrash size={18} />
+                </ActionIcon>
+              )}
+            </Group>
+            <Text size="xs" c="dimmed" className="mt-1">
+              조회 {post.views}
+            </Text>
+
+            <Text className="mt-4 whitespace-pre-wrap">{post.content}</Text>
+
+            <Divider className="my-6" />
+
+            <Text fw={600} className="mb-3">
+              댓글
+            </Text>
+            <ScrollArea.Autosize mah={300} className="scrollbar-brand">
+              <Stack gap="sm">
+                {comments.map((c) => (
+                  <div key={c.id}>
+                    <Group gap="xs">
+                      <Text size="sm" fw={600}>
+                        {c.profiles.display_name}
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        {c.created_at}
+                      </Text>
+                    </Group>
+                    <Text size="sm" className="mt-1">
+                      {c.content}
+                    </Text>
+                  </div>
+                ))}
+                {comments.length === 0 && (
+                  <Text size="sm" c="dimmed">
+                    아직 댓글이 없습니다.
+                  </Text>
+                )}
+              </Stack>
+            </ScrollArea.Autosize>
+
+            {user && (
+              <Group className="mt-4">
+                <TextInput
+                  placeholder="댓글을 입력해주세요."
+                  value={comment}
+                  onChange={(e) => setComment(e.currentTarget.value)}
+                  className="flex-1"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleComment();
+                  }}
+                />
+                <ActionIcon
+                  onClick={handleComment}
+                  loading={commentMutation.isPending}
+                  variant="filled"
+                >
+                  <IconSend size={16} />
+                </ActionIcon>
+              </Group>
+            )}
+          </div>
+        </div>
+
+        <Card.Section className="border-t border-gray-200 p-4">
+          <Text
+            component={Link}
+            href="/sharing"
+            size="sm"
+            c="dimmed"
+            className="cursor-pointer hover:underline"
+          >
+            교환/나눔 게시글 목록보기
+          </Text>
+        </Card.Section>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/sharing/[id]/page.tsx
+++ b/src/app/sharing/[id]/page.tsx
@@ -1,222 +1,30 @@
-'use client';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import getQueryClient from '@/libs/query/query-client';
+import { createClient } from '@/libs/supabase/server';
+import { sharingQueries } from '@/services/sharing/queries';
+import { servFetchSharingDetail } from '@/services/sharing/sharing-services';
+import SharingDetailContents from './components/SharingDetailContents';
 
-import { useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import Image from 'next/image';
-import Link from 'next/link';
-import {
-  Card,
-  Text,
-  Title,
-  Stack,
-  Group,
-  Avatar,
-  Button,
-  TextInput,
-  Divider,
-  Center,
-  Loader,
-  Alert,
-  ActionIcon,
-  ScrollArea,
-} from '@mantine/core';
-import { IconTrash, IconMessageCircle, IconSend } from '@tabler/icons-react';
-import {
-  useSharingDetail,
-  useDeleteSharingPost,
-  useAddSharingComment,
-} from '@/services/sharing/useSharing';
-import { useCreateChatRoom } from '@/services/chat/useChat';
-import { useUser } from '@/services/auth/useUser';
+interface SharingDetailPageProps {
+  params: Promise<{ id: string }>;
+}
 
-export default function SharingDetailPage() {
-  const { id } = useParams<{ id: string }>();
+export default async function SharingDetailPage({
+  params,
+}: SharingDetailPageProps) {
+  const { id } = await params;
   const postId = Number(id);
-  const router = useRouter();
-  const { user } = useUser();
-  const [comment, setComment] = useState('');
+  const queryClient = getQueryClient();
+  const supabase = await createClient();
 
-  const { data, isLoading } = useSharingDetail(postId);
-  const deleteMutation = useDeleteSharingPost();
-  const commentMutation = useAddSharingComment();
-  const createChatRoom = useCreateChatRoom();
-
-  if (isLoading) {
-    return (
-      <Center className="min-h-[60vh]">
-        <Loader size="lg" />
-      </Center>
-    );
-  }
-
-  if (!data) {
-    return (
-      <Alert color="red" className="mx-auto mt-10 max-w-md">
-        게시글을 찾을 수 없습니다.
-      </Alert>
-    );
-  }
-
-  const { post, comments } = data;
-  const isAuthor = user?.id === post.user_id;
-
-  function handleDelete() {
-    if (!user) return;
-    deleteMutation.mutate(postId, {
-      onSuccess: () => router.push('/sharing'),
-    });
-  }
-
-  function handleComment() {
-    if (!comment.trim() || !user) return;
-    commentMutation.mutate(
-      { postId, content: comment },
-      { onSuccess: () => setComment('') }
-    );
-  }
-
-  function handleChat() {
-    if (!user) return;
-    createChatRoom.mutate(
-      { postId, otherUserId: post.user_id },
-      { onSuccess: () => router.push('/chat') }
-    );
-  }
+  await queryClient.prefetchQuery({
+    ...sharingQueries.detail(postId),
+    queryFn: () => servFetchSharingDetail(postId, supabase),
+  });
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-10">
-      <Card shadow="sm" radius="md" withBorder>
-        <Card.Section className="border-b border-gray-200 p-4">
-          <Text fw={600}>교환 &amp; 나눔 게시판</Text>
-        </Card.Section>
-
-        <div className="flex flex-col gap-6 p-6 md:flex-row">
-          <div className="flex flex-col gap-4 md:w-1/2">
-            <div className="relative aspect-square overflow-hidden rounded-md">
-              <Image
-                src={post.image_url || '/images/도담덕로고.png'}
-                alt={post.title}
-                fill
-                className="object-cover"
-                unoptimized
-              />
-            </div>
-
-            <Group>
-              <Avatar
-                src={post.profiles.profile_url || undefined}
-                size="lg"
-                radius="xl"
-              />
-              <Stack gap={2}>
-                <Text fw={600}>{post.profiles.display_name} 님</Text>
-                <Text size="xs" c="dimmed">
-                  {post.location}
-                </Text>
-                <Text size="xs" c="dimmed">
-                  {post.created_at}
-                </Text>
-              </Stack>
-            </Group>
-
-            {user && !isAuthor && (
-              <Button
-                leftSection={<IconMessageCircle size={16} />}
-                onClick={handleChat}
-                loading={createChatRoom.isPending}
-              >
-                채팅하기
-              </Button>
-            )}
-          </div>
-
-          <Divider orientation="vertical" className="hidden md:block" />
-
-          <div className="flex flex-1 flex-col">
-            <Group justify="space-between">
-              <Title order={3}>{post.title}</Title>
-              {isAuthor && (
-                <ActionIcon
-                  variant="subtle"
-                  color="red"
-                  onClick={handleDelete}
-                  loading={deleteMutation.isPending}
-                >
-                  <IconTrash size={18} />
-                </ActionIcon>
-              )}
-            </Group>
-            <Text size="xs" c="dimmed" className="mt-1">
-              조회 {post.views}
-            </Text>
-
-            <Text className="mt-4 whitespace-pre-wrap">{post.content}</Text>
-
-            <Divider className="my-6" />
-
-            <Text fw={600} className="mb-3">
-              댓글
-            </Text>
-            <ScrollArea.Autosize mah={300} className="scrollbar-brand">
-              <Stack gap="sm">
-                {comments.map((c) => (
-                  <div key={c.id}>
-                    <Group gap="xs">
-                      <Text size="sm" fw={600}>
-                        {c.profiles.display_name}
-                      </Text>
-                      <Text size="xs" c="dimmed">
-                        {c.created_at}
-                      </Text>
-                    </Group>
-                    <Text size="sm" className="mt-1">
-                      {c.content}
-                    </Text>
-                  </div>
-                ))}
-                {comments.length === 0 && (
-                  <Text size="sm" c="dimmed">
-                    아직 댓글이 없습니다.
-                  </Text>
-                )}
-              </Stack>
-            </ScrollArea.Autosize>
-
-            {user && (
-              <Group className="mt-4">
-                <TextInput
-                  placeholder="댓글을 입력해주세요."
-                  value={comment}
-                  onChange={(e) => setComment(e.currentTarget.value)}
-                  className="flex-1"
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleComment();
-                  }}
-                />
-                <ActionIcon
-                  onClick={handleComment}
-                  loading={commentMutation.isPending}
-                  variant="filled"
-                >
-                  <IconSend size={16} />
-                </ActionIcon>
-              </Group>
-            )}
-          </div>
-        </div>
-
-        <Card.Section className="border-t border-gray-200 p-4">
-          <Text
-            component={Link}
-            href="/sharing"
-            size="sm"
-            c="dimmed"
-            className="cursor-pointer hover:underline"
-          >
-            교환/나눔 게시글 목록보기
-          </Text>
-        </Card.Section>
-      </Card>
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <SharingDetailContents />
+    </HydrationBoundary>
   );
 }

--- a/src/app/sharing/components/SharingContents.tsx
+++ b/src/app/sharing/components/SharingContents.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+  Card,
+  Text,
+  Title,
+  Stack,
+  TextInput,
+  Badge,
+  Group,
+  SimpleGrid,
+  Center,
+  Loader,
+  ActionIcon,
+  Alert,
+  Affix,
+} from '@mantine/core';
+import { IconSearch, IconPlus } from '@tabler/icons-react';
+import {
+  useSharingList,
+  useSharingSearch,
+  usePopularSearches,
+  useIncrementSharingViewCount,
+} from '@/services/sharing/useSharing';
+import { useUser } from '@/services/auth/useUser';
+import { formatTimeSince } from '@/libs/format-date';
+
+export default function SharingContents() {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeSearch, setActiveSearch] = useState('');
+  const router = useRouter();
+  const { user } = useUser();
+
+  const { data: posts, isLoading } = useSharingList();
+  const { data: searchResults } = useSharingSearch(activeSearch);
+  const { data: popularSearches } = usePopularSearches();
+  const incrementView = useIncrementSharingViewCount();
+
+  const displayPosts = activeSearch ? searchResults : posts;
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    setActiveSearch(searchQuery);
+  }
+
+  function handleCardClick(postId: number) {
+    incrementView.mutate(postId);
+    router.push(`/sharing/${postId}`);
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10">
+      <Stack align="center" gap="xs" className="mb-8">
+        <Text c="dimmed" size="lg">
+          나눔을 통해 행복을 나누다
+        </Text>
+        <Title order={1}>교환 &amp; 나눔</Title>
+      </Stack>
+
+      <form onSubmit={handleSearch} className="mx-auto mb-6 max-w-lg">
+        <TextInput
+          placeholder="어떤 제품을 찾으세요?"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.currentTarget.value)}
+          rightSection={
+            <ActionIcon type="submit" variant="subtle">
+              <IconSearch size={18} />
+            </ActionIcon>
+          }
+        />
+      </form>
+
+      {popularSearches && popularSearches.length > 0 && (
+        <Group gap="xs" justify="center" className="mb-8">
+          {popularSearches.slice(0, 5).map((item) => (
+            <Badge
+              key={item.query}
+              variant="outline"
+              className="cursor-pointer"
+              onClick={() => {
+                setSearchQuery(item.query);
+                setActiveSearch(item.query);
+              }}
+            >
+              #{item.query}
+            </Badge>
+          ))}
+        </Group>
+      )}
+
+      {isLoading && (
+        <Center className="min-h-[40vh]">
+          <Loader size="lg" />
+        </Center>
+      )}
+
+      {displayPosts && (
+        <SimpleGrid cols={{ base: 1, xs: 2, sm: 3, md: 4 }} spacing="lg">
+          {displayPosts.map((post) => (
+            <Card
+              key={post.id}
+              shadow="sm"
+              padding="sm"
+              radius="md"
+              withBorder
+              className="cursor-pointer transition-all hover:-translate-y-1 hover:shadow-lg"
+              onClick={() => handleCardClick(post.id)}
+            >
+              <Card.Section className="relative h-48">
+                <Image
+                  src={post.image_url || '/images/도담덕로고.png'}
+                  alt={post.title}
+                  fill
+                  className="object-cover"
+                  unoptimized
+                />
+              </Card.Section>
+
+              <Text fw={600} size="sm" className="mt-3" lineClamp={1}>
+                {post.title}
+              </Text>
+              <Text size="xs" c="dimmed" className="mt-1">
+                {post.location} · {formatTimeSince(post.created_at)} · 조회{' '}
+                {post.views}
+              </Text>
+              <Badge size="sm" variant="light" className="mt-2">
+                {post.exchange_option}
+              </Badge>
+              {post.tags && post.tags.length > 0 && (
+                <Group gap={4} className="mt-1">
+                  {post.tags.map((tag) => (
+                    <Text key={tag} size="xs" c="dimmed">
+                      #{tag}
+                    </Text>
+                  ))}
+                </Group>
+              )}
+            </Card>
+          ))}
+        </SimpleGrid>
+      )}
+
+      {displayPosts && displayPosts.length === 0 && (
+        <Alert className="mx-auto max-w-md">게시글이 없습니다.</Alert>
+      )}
+
+      {user && (
+        <Affix position={{ bottom: 40, right: 40 }}>
+          <ActionIcon
+            component={Link}
+            href="/sharing/new"
+            size={56}
+            radius="xl"
+            variant="filled"
+          >
+            <IconPlus size={24} />
+          </ActionIcon>
+        </Affix>
+      )}
+    </div>
+  );
+}

--- a/src/app/sharing/page.tsx
+++ b/src/app/sharing/page.tsx
@@ -1,166 +1,31 @@
-'use client';
-
-import { useState } from 'react';
-import Image from 'next/image';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import getQueryClient from '@/libs/query/query-client';
+import { createClient } from '@/libs/supabase/server';
+import { sharingQueries } from '@/services/sharing/queries';
 import {
-  Card,
-  Text,
-  Title,
-  Stack,
-  TextInput,
-  Badge,
-  Group,
-  SimpleGrid,
-  Center,
-  Loader,
-  ActionIcon,
-  Alert,
-  Affix,
-} from '@mantine/core';
-import { IconSearch, IconPlus } from '@tabler/icons-react';
-import {
-  useSharingList,
-  useSharingSearch,
-  usePopularSearches,
-  useIncrementSharingViewCount,
-} from '@/services/sharing/useSharing';
-import { useUser } from '@/services/auth/useUser';
-import { formatTimeSince } from '@/libs/format-date';
+  servFetchSharingPosts,
+  servFetchPopularSearches,
+} from '@/services/sharing/sharing-services';
+import SharingContents from './components/SharingContents';
 
-export default function SharingPage() {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [activeSearch, setActiveSearch] = useState('');
-  const router = useRouter();
-  const { user } = useUser();
+export default async function SharingPage() {
+  const queryClient = getQueryClient();
+  const supabase = await createClient();
 
-  const { data: posts, isLoading } = useSharingList();
-  const { data: searchResults } = useSharingSearch(activeSearch);
-  const { data: popularSearches } = usePopularSearches();
-  const incrementView = useIncrementSharingViewCount();
-
-  const displayPosts = activeSearch ? searchResults : posts;
-
-  function handleSearch(e: React.FormEvent) {
-    e.preventDefault();
-    setActiveSearch(searchQuery);
-  }
-
-  function handleCardClick(postId: number) {
-    incrementView.mutate(postId);
-    router.push(`/sharing/${postId}`);
-  }
+  await Promise.all([
+    queryClient.prefetchQuery({
+      ...sharingQueries.all(),
+      queryFn: () => servFetchSharingPosts(supabase),
+    }),
+    queryClient.prefetchQuery({
+      ...sharingQueries.popularSearches(),
+      queryFn: () => servFetchPopularSearches(supabase),
+    }),
+  ]);
 
   return (
-    <div className="mx-auto max-w-6xl px-4 py-10">
-      <Stack align="center" gap="xs" className="mb-8">
-        <Text c="dimmed" size="lg">
-          나눔을 통해 행복을 나누다
-        </Text>
-        <Title order={1}>교환 &amp; 나눔</Title>
-      </Stack>
-
-      <form onSubmit={handleSearch} className="mx-auto mb-6 max-w-lg">
-        <TextInput
-          placeholder="어떤 제품을 찾으세요?"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.currentTarget.value)}
-          rightSection={
-            <ActionIcon type="submit" variant="subtle">
-              <IconSearch size={18} />
-            </ActionIcon>
-          }
-        />
-      </form>
-
-      {popularSearches && popularSearches.length > 0 && (
-        <Group gap="xs" justify="center" className="mb-8">
-          {popularSearches.slice(0, 5).map((item) => (
-            <Badge
-              key={item.query}
-              variant="outline"
-              className="cursor-pointer"
-              onClick={() => {
-                setSearchQuery(item.query);
-                setActiveSearch(item.query);
-              }}
-            >
-              #{item.query}
-            </Badge>
-          ))}
-        </Group>
-      )}
-
-      {isLoading && (
-        <Center className="min-h-[40vh]">
-          <Loader size="lg" />
-        </Center>
-      )}
-
-      {displayPosts && (
-        <SimpleGrid cols={{ base: 1, xs: 2, sm: 3, md: 4 }} spacing="lg">
-          {displayPosts.map((post) => (
-            <Card
-              key={post.id}
-              shadow="sm"
-              padding="sm"
-              radius="md"
-              withBorder
-              className="cursor-pointer transition-all hover:-translate-y-1 hover:shadow-lg"
-              onClick={() => handleCardClick(post.id)}
-            >
-              <Card.Section className="relative h-48">
-                <Image
-                  src={post.image_url || '/images/도담덕로고.png'}
-                  alt={post.title}
-                  fill
-                  className="object-cover"
-                  unoptimized
-                />
-              </Card.Section>
-
-              <Text fw={600} size="sm" className="mt-3" lineClamp={1}>
-                {post.title}
-              </Text>
-              <Text size="xs" c="dimmed" className="mt-1">
-                {post.location} · {formatTimeSince(post.created_at)} · 조회{' '}
-                {post.views}
-              </Text>
-              <Badge size="sm" variant="light" className="mt-2">
-                {post.exchange_option}
-              </Badge>
-              {post.tags && post.tags.length > 0 && (
-                <Group gap={4} className="mt-1">
-                  {post.tags.map((tag) => (
-                    <Text key={tag} size="xs" c="dimmed">
-                      #{tag}
-                    </Text>
-                  ))}
-                </Group>
-              )}
-            </Card>
-          ))}
-        </SimpleGrid>
-      )}
-
-      {displayPosts && displayPosts.length === 0 && (
-        <Alert className="mx-auto max-w-md">게시글이 없습니다.</Alert>
-      )}
-
-      {user && (
-        <Affix position={{ bottom: 40, right: 40 }}>
-          <ActionIcon
-            component={Link}
-            href="/sharing/new"
-            size={56}
-            radius="xl"
-            variant="filled"
-          >
-            <IconPlus size={24} />
-          </ActionIcon>
-        </Affix>
-      )}
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <SharingContents />
+    </HydrationBoundary>
   );
 }

--- a/src/libs/query/query-client.ts
+++ b/src/libs/query/query-client.ts
@@ -1,0 +1,16 @@
+import { QueryClient } from '@tanstack/react-query';
+import { cache } from 'react';
+
+const queryClient = cache(
+  () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          staleTime: 5 * 60 * 1000,
+          gcTime: 30 * 60 * 1000,
+        },
+      },
+    })
+);
+
+export default queryClient;

--- a/src/services/board/board-services.ts
+++ b/src/services/board/board-services.ts
@@ -1,5 +1,7 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@/libs/supabase/client';
 import { uploadImage } from '@/libs/supabase/storage';
+import type { Database } from '@/types/supabase';
 import type {
   BoardPost,
   BoardDetailResponse,
@@ -8,8 +10,10 @@ import type {
   BoardComment,
 } from './board.types';
 
-export async function servFetchBoardPosts(): Promise<BoardPost[]> {
-  const supabase = createClient();
+export async function servFetchBoardPosts(
+  client?: SupabaseClient<Database>
+): Promise<BoardPost[]> {
+  const supabase = client ?? createClient();
 
   const { data, error } = await supabase
     .from('board_posts')
@@ -21,9 +25,10 @@ export async function servFetchBoardPosts(): Promise<BoardPost[]> {
 }
 
 export async function servFetchBoardDetail(
-  postId: number
+  postId: number,
+  client?: SupabaseClient<Database>
 ): Promise<BoardDetailResponse> {
-  const supabase = createClient();
+  const supabase = client ?? createClient();
 
   const { data: post, error: postError } = await supabase
     .from('board_posts')

--- a/src/services/board/queries.ts
+++ b/src/services/board/queries.ts
@@ -8,7 +8,7 @@ export const boardQueries = {
   all: () =>
     queryOptions({
       queryKey: ['board', 'list'] as const,
-      queryFn: servFetchBoardPosts,
+      queryFn: () => servFetchBoardPosts(),
       staleTime: 5 * 60 * 1000,
       gcTime: 30 * 60 * 1000,
     }),

--- a/src/services/chat/chat-services.ts
+++ b/src/services/chat/chat-services.ts
@@ -1,4 +1,6 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@/libs/supabase/client';
+import type { Database } from '@/types/supabase';
 import type {
   ChatRoom,
   ChatMessage,
@@ -6,8 +8,10 @@ import type {
   SendMessageRequest,
 } from './chat.types';
 
-export async function servFetchChatList(): Promise<ChatRoom[]> {
-  const supabase = createClient();
+export async function servFetchChatList(
+  client?: SupabaseClient<Database>
+): Promise<ChatRoom[]> {
+  const supabase = client ?? createClient();
 
   const {
     data: { user },
@@ -27,9 +31,10 @@ export async function servFetchChatList(): Promise<ChatRoom[]> {
 }
 
 export async function servFetchMessages(
-  roomId: number
+  roomId: number,
+  client?: SupabaseClient<Database>
 ): Promise<ChatMessage[]> {
-  const supabase = createClient();
+  const supabase = client ?? createClient();
 
   const { data, error } = await supabase
     .from('chat_messages')

--- a/src/services/library/library-services.ts
+++ b/src/services/library/library-services.ts
@@ -80,3 +80,31 @@ export async function servFetchLibraryItems(
   const data: LibraryResponse = await response.json();
   return data.data;
 }
+
+export async function servFetchLibraryItemsServer(
+  page = 1,
+  perPage = 30
+): Promise<LibraryItem[]> {
+  const apiUrl = process.env.ODCLOUD_API_URL;
+  const apiKey = process.env.ODCLOUD_API_KEY;
+  const datasetPath = process.env.ODCLOUD_LIBRARY_DATASET_PATH;
+
+  if (!apiUrl || !apiKey || !datasetPath) {
+    throw new Error('Server configuration error');
+  }
+
+  const params = new URLSearchParams({
+    page: String(page),
+    perPage: String(perPage),
+    returnType: 'JSON',
+    serviceKey: apiKey,
+  });
+
+  const response = await fetch(
+    `${apiUrl}${datasetPath}?${params.toString()}`
+  );
+  if (!response.ok) throw new Error('장난감 도서관 데이터를 불러올 수 없습니다');
+
+  const data: LibraryResponse = await response.json();
+  return data.data;
+}

--- a/src/services/sharing/queries.ts
+++ b/src/services/sharing/queries.ts
@@ -10,7 +10,7 @@ export const sharingQueries = {
   all: () =>
     queryOptions({
       queryKey: ['sharing', 'list'] as const,
-      queryFn: servFetchSharingPosts,
+      queryFn: () => servFetchSharingPosts(),
       staleTime: 5 * 60 * 1000,
       gcTime: 30 * 60 * 1000,
     }),
@@ -35,7 +35,7 @@ export const sharingQueries = {
   popularSearches: () =>
     queryOptions({
       queryKey: ['sharing', 'popularSearches'] as const,
-      queryFn: servFetchPopularSearches,
+      queryFn: () => servFetchPopularSearches(),
       staleTime: 10 * 60 * 1000,
       gcTime: 30 * 60 * 1000,
     }),

--- a/src/services/sharing/sharing-services.ts
+++ b/src/services/sharing/sharing-services.ts
@@ -1,5 +1,7 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@/libs/supabase/client';
 import { uploadImage } from '@/libs/supabase/storage';
+import type { Database } from '@/types/supabase';
 import type {
   SharingPost,
   SharingDetailResponse,
@@ -9,8 +11,10 @@ import type {
   PopularSearch,
 } from './sharing.types';
 
-export async function servFetchSharingPosts(): Promise<SharingPost[]> {
-  const supabase = createClient();
+export async function servFetchSharingPosts(
+  client?: SupabaseClient<Database>
+): Promise<SharingPost[]> {
+  const supabase = client ?? createClient();
 
   const { data, error } = await supabase
     .from('sharing_posts')
@@ -22,9 +26,10 @@ export async function servFetchSharingPosts(): Promise<SharingPost[]> {
 }
 
 export async function servFetchSharingDetail(
-  postId: number
+  postId: number,
+  client?: SupabaseClient<Database>
 ): Promise<SharingDetailResponse> {
-  const supabase = createClient();
+  const supabase = client ?? createClient();
 
   const { data: post, error: postError } = await supabase
     .from('sharing_posts')
@@ -120,9 +125,10 @@ export async function servAddSharingComment(
 }
 
 export async function servSearchSharingPosts(
-  query: string
+  query: string,
+  client?: SupabaseClient<Database>
 ): Promise<SharingPost[]> {
-  const supabase = createClient();
+  const supabase = client ?? createClient();
 
   const { data, error } = await supabase.rpc('search_sharing_posts', {
     search_query: query,
@@ -146,8 +152,10 @@ export async function servSearchSharingPosts(
   return posts as SharingPost[];
 }
 
-export async function servFetchPopularSearches(): Promise<PopularSearch[]> {
-  const supabase = createClient();
+export async function servFetchPopularSearches(
+  client?: SupabaseClient<Database>
+): Promise<PopularSearch[]> {
+  const supabase = client ?? createClient();
 
   const { data, error } = await supabase.rpc('get_popular_searches', {
     limit_count: 5,


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                       
  - 8개 페이지의 page.tsx를 Server Component로 전환하고, TanStack Query `prefetchQuery` + `HydrationBoundary`로 서버에서 데이터를 미리 로드                                                                                        
  - 인증 페이지(chat, my-shop)는 서버에서 auth 확인 후 redirect 처리하여 클라이언트 로딩 스피너 제거
  - 서비스 함수에 서버 Supabase 클라이언트를 주입할 수 있도록 옵셔널 파라미터 추가

  ## 변경 내용
  - `getQueryClient` 유틸리티 추가 (`React.cache` 기반 요청 스코프 싱글턴)
  - 공개 페이지(sharing, board, library) 서버 프리페칭 적용
  - 인증 페이지(chat, my-shop) 서버 인증 가드 + user/profile props 전달
  - 장난감 도서관 API 경로를 환경변수(`ODCLOUD_LIBRARY_DATASET_PATH`)로 분리

  ## Test plan
  - [x] `/sharing`, `/board`, `/library` 새로고침 시 로딩 스피너 없이 데이터 즉시 표시 확인
  - [x] `/sharing/[id]`, `/board/[id]` 상세 페이지 진입 시 데이터 즉시 표시 확인
  - [x] `/chat`, `/my-shop` 비로그인 상태에서 접근 시 로그인 페이지로 redirect 확인
  - [x] `/chat`, `/my-shop` 로그인 상태에서 새로고침 시 로딩 스피너 없이 렌더 확인
  - [x] 검색, 댓글 작성, 채팅 전송 등 클라이언트 인터랙션 정상 동작 확인