### PR TITLE
fix: 상세 페이지/댓글의 날짜를 포맷팅하여 표시

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,8 +24,9 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--model claude-sonnet-4-20250514"
+          claude_args: "--model sonnet"
           use_sticky_comment: true
+          show_full_output: true
           prompt: |
             이 PR의 변경사항을 리뷰해주세요.
             코드 품질, 버그 가능성, 보안 문제를 중심으로 검토하고,

--- a/src/app/board/[id]/components/BoardDetailContents.tsx
+++ b/src/app/board/[id]/components/BoardDetailContents.tsx
@@ -20,6 +20,7 @@ import {
   useIncrementBoardViewCount,
 } from '@/services/board/useBoard';
 import { useUser } from '@/services/auth/useUser';
+import { formatDateTime } from '@/libs/format-date';
 
 export default function BoardDetailContents() {
   const { id } = useParams<{ id: string }>();
@@ -96,7 +97,7 @@ export default function BoardDetailContents() {
                 </Avatar>
                 <div className="flex flex-col gap-0.5">
                   <p className="font-semibold">{post.profiles.display_name} 님</p>
-                  <p className="text-xs text-muted-foreground">{post.created_at}</p>
+                  <p className="text-xs text-muted-foreground">{formatDateTime(post.created_at)}</p>
                 </div>
               </div>
             </div>

--- a/src/app/sharing/[id]/components/SharingDetailContents.tsx
+++ b/src/app/sharing/[id]/components/SharingDetailContents.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/services/sharing/useSharing';
 import { useCreateChatRoom } from '@/services/chat/useChat';
 import { useUser } from '@/services/auth/useUser';
+import { formatDateTime } from '@/libs/format-date';
 
 export default function SharingDetailContents() {
   const { id } = useParams<{ id: string }>();
@@ -108,7 +109,7 @@ export default function SharingDetailContents() {
                 <div className="flex flex-col gap-0.5">
                   <p className="font-semibold">{post.profiles.display_name} 님</p>
                   <p className="text-xs text-muted-foreground">{post.location}</p>
-                  <p className="text-xs text-muted-foreground">{post.created_at}</p>
+                  <p className="text-xs text-muted-foreground">{formatDateTime(post.created_at)}</p>
                 </div>
               </div>
 

--- a/src/components/common/CommentSection.tsx
+++ b/src/components/common/CommentSection.tsx
@@ -7,6 +7,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { LoadingButton } from '@/components/common/LoadingButton';
 import { EmptyState } from '@/components/common/EmptyState';
 import { cn } from '@/lib/utils';
+import { formatTimeSince } from '@/libs/format-date';
 
 interface Comment {
   id: number;
@@ -52,7 +53,7 @@ export function CommentSection({
                   {c.profiles.display_name}
                 </p>
                 <p className="text-xs text-muted-foreground">
-                  {c.created_at}
+                  {formatTimeSince(c.created_at)}
                 </p>
               </div>
               <p className="mt-1 text-sm">{c.content}</p>

--- a/src/libs/format-date.ts
+++ b/src/libs/format-date.ts
@@ -2,9 +2,34 @@ export function formatTimeSince(dateString: string): string {
   const date = new Date(dateString);
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
-  if (diffDays === 0) return '오늘';
-  if (diffDays === 1) return '1일 전';
-  return `${diffDays}일 전`;
+  if (diffMin < 1) return '방금 전';
+  if (diffMin < 60) return `${diffMin}분 전`;
+  if (diffHours < 24) return `${diffHours}시간 전`;
+  if (diffDays < 7) return `${diffDays}일 전`;
+
+  return formatDate(dateString);
+}
+
+export function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}.${month}.${day}`;
+}
+
+export function formatDateTime(dateString: string): string {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+
+  return `${year}.${month}.${day} ${hours}:${minutes}`;
 }


### PR DESCRIPTION
## 작업 내용
- raw ISO 문자열이 그대로 노출되던 문제 수정
   - 게시글 작성일은 "2026.06.21 09:31" 형식,                                                                                                                                                                                         
   - 댓글은 "3분 전", "2시간 전" 등 상대 시간으로 표시.      
   - formatTimeSince에 분/시간 단위 추가