### PR TITLE
refactor(ui): Tailwind 임의값·인라인 스타일 위반 수정

### DIFF
--- a/src/app/chat/[id]/components/ChatDetailContents.tsx
+++ b/src/app/chat/[id]/components/ChatDetailContents.tsx
@@ -130,7 +130,7 @@ export default function ChatDetailContents({ user, profile }: ChatDetailContents
 
           <div
             ref={viewport}
-            className="scrollbar-brand h-[400px] flex-1 overflow-y-auto p-4"
+            className="scrollbar-brand h-100 flex-1 overflow-y-auto p-4"
           >
             <div className="flex flex-col gap-3">
               {messages?.map((msg) => {

--- a/src/app/library/components/LibraryContents.tsx
+++ b/src/app/library/components/LibraryContents.tsx
@@ -17,8 +17,8 @@ function ToyCard({ item }: { item: LibraryItem }) {
   return (
     <div className="overflow-hidden rounded-lg border bg-card transition-all hover:-translate-y-1 hover:shadow-lg">
       <div
-        className="flex h-[140px] items-center justify-center"
-        style={{ background: config.gradient }}
+        className="flex h-35 items-center justify-center [background:var(--card-gradient)]"
+        style={{ '--card-gradient': config.gradient } as React.CSSProperties}
       >
         <Icon size={56} color="white" strokeWidth={1.5} />
       </div>

--- a/src/app/my-shop/components/MyShopContents.tsx
+++ b/src/app/my-shop/components/MyShopContents.tsx
@@ -34,7 +34,7 @@ export default function MyShopContents({ user, profile }: MyShopContentsProps) {
       <div className="flex w-full max-w-4xl flex-col gap-8">
       <Card>
         <CardContent className="flex items-center gap-4 p-6">
-          <Avatar className="h-[120px] w-[120px]">
+          <Avatar className="h-30 w-30">
             <AvatarImage src={profile.profile_url || undefined} />
             <AvatarFallback className="text-2xl">
               {profile.display_name?.[0] ?? '?'}

--- a/src/components/common/CommentSection.tsx
+++ b/src/components/common/CommentSection.tsx
@@ -44,7 +44,7 @@ export function CommentSection({
   return (
     <div className={cn('flex flex-col gap-3', className)}>
       <p className="font-semibold">댓글</p>
-      <ScrollArea className="scrollbar-brand h-[300px]">
+      <ScrollArea className="scrollbar-brand h-75">
         <div className="flex flex-col gap-3">
           {comments.map((c) => (
             <div key={c.id} className="flex flex-col gap-1">


### PR DESCRIPTION
## 작업 내용
- `h-[140px]`, `w-[120px]` 등 arbitrary px 값을 Tailwind scale(`h-35`, `h-30 w-30`)로 전환                                                                                                             
- `style={{ background }}` 인라인 스타일을 CSS 변수 패턴(`--card-gradient`)으로 전환