### PR TITLE
feat: 장난감 교환 페이지 댓글 삭제 기능 추가

### DIFF
--- a/src/__tests__/mocks/factories.ts
+++ b/src/__tests__/mocks/factories.ts
@@ -38,6 +38,7 @@ export function createMockSharingDetail(
       {
         id: 1,
         post_id: 1,
+        user_id: 'comment-user-1',
         content: '교환 원합니다',
         created_at: '2024-01-02T00:00:00Z',
         profiles: {

--- a/src/__tests__/services/sharing-services.test.ts
+++ b/src/__tests__/services/sharing-services.test.ts
@@ -2,7 +2,9 @@ import { createClient } from '@/libs/supabase/client';
 import {
   servFetchSharingPosts,
   servFetchPopularSearches,
+  servDeleteSharingComment,
 } from '@/services/sharing/sharing-services';
+import { createMockUser } from '../mocks/supabase';
 import { createMockSharingPost } from '../mocks/factories';
 import type { MockSupabaseClient } from '../mocks/supabase';
 
@@ -40,6 +42,61 @@ describe('servFetchSharingPosts', () => {
     })) as ReturnType<typeof vi.fn>;
 
     await expect(servFetchSharingPosts()).rejects.toThrow();
+  });
+});
+
+describe('servDeleteSharingComment', () => {
+  it('본인 댓글을 정상적으로 삭제한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    const eqSecond = vi.fn(() =>
+      Promise.resolve({ error: null, count: 1 })
+    );
+    const eqFirst = vi.fn(() => ({ eq: eqSecond }));
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn(() => ({ eq: eqFirst })),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(servDeleteSharingComment(1)).resolves.toBeUndefined();
+    expect(eqFirst).toHaveBeenCalledWith('id', 1);
+    expect(eqSecond).toHaveBeenCalledWith('user_id', mockUser.id);
+  });
+
+  it('다른 사용자의 댓글 삭제 시 에러를 던진다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    const eqSecond = vi.fn(() =>
+      Promise.resolve({ error: null, count: 0 })
+    );
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn(() => ({ eq: vi.fn(() => ({ eq: eqSecond })) })),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(servDeleteSharingComment(99)).rejects.toThrow(
+      '삭제 권한이 없거나 존재하지 않는 댓글입니다.'
+    );
+  });
+
+  it('미인증 사용자는 에러를 던진다', async () => {
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: null }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    await expect(servDeleteSharingComment(1)).rejects.toThrow(
+      '인증이 필요합니다'
+    );
   });
 });
 

--- a/src/app/sharing/[id]/components/SharingDetailContents.tsx
+++ b/src/app/sharing/[id]/components/SharingDetailContents.tsx
@@ -18,6 +18,7 @@ import {
   useSharingDetail,
   useDeleteSharingPost,
   useAddSharingComment,
+  useDeleteSharingComment,
   useIncrementSharingViewCount,
 } from '@/services/sharing/useSharing';
 import { useCreateChatRoom } from '@/services/chat/useChat';
@@ -33,6 +34,7 @@ export default function SharingDetailContents() {
 
   const { data, isLoading } = useSharingDetail(postId);
   const deleteMutation = useDeleteSharingPost();
+  const deleteCommentMutation = useDeleteSharingComment(postId);
   const commentMutation = useAddSharingComment();
   const createChatRoom = useCreateChatRoom();
   const incrementView = useIncrementSharingViewCount();
@@ -167,6 +169,13 @@ export default function SharingDetailContents() {
                 isLoggedIn={!!user}
                 onSubmit={handleComment}
                 isSubmitting={commentMutation.isPending}
+                onDelete={(commentId) => deleteCommentMutation.mutate(commentId)}
+                currentUserId={user?.id}
+                isDeletingId={
+                  deleteCommentMutation.isPending
+                    ? (deleteCommentMutation.variables ?? null)
+                    : null
+                }
               />
             </div>
           </div>

--- a/src/services/sharing/sharing-services.ts
+++ b/src/services/sharing/sharing-services.ts
@@ -41,7 +41,7 @@ export async function servFetchSharingDetail(
 
   const { data: comments, error: commentsError } = await supabase
     .from('sharing_comments')
-    .select('*, profiles(username, display_name)')
+    .select('id, post_id, user_id, content, created_at, profiles(username, display_name)')
     .eq('post_id', postId)
     .order('created_at', { ascending: true });
 
@@ -122,6 +122,26 @@ export async function servAddSharingComment(
   });
 
   if (error) throw error;
+}
+
+export async function servDeleteSharingComment(
+  commentId: number
+): Promise<void> {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('인증이 필요합니다');
+
+  const { error, count } = await supabase
+    .from('sharing_comments')
+    .delete({ count: 'exact' })
+    .eq('id', commentId)
+    .eq('user_id', user.id);
+
+  if (error) throw error;
+  if (!count) throw new Error('삭제 권한이 없거나 존재하지 않는 댓글입니다.');
 }
 
 export async function servSearchSharingPosts(

--- a/src/services/sharing/sharing.types.ts
+++ b/src/services/sharing/sharing.types.ts
@@ -14,6 +14,7 @@ export interface SharingPost extends SharingPostRow {
 export interface SharingComment {
   id: number;
   post_id: number;
+  user_id: string;
   content: string;
   created_at: string;
   profiles: {

--- a/src/services/sharing/useSharing.ts
+++ b/src/services/sharing/useSharing.ts
@@ -1,10 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { sharingQueries } from './queries';
 import {
   servCreateSharingPost,
   servDeleteSharingPost,
   servIncrementSharingViewCount,
   servAddSharingComment,
+  servDeleteSharingComment,
 } from './sharing-services';
 import type {
   CreateSharingPostRequest,
@@ -60,6 +62,23 @@ export function useIncrementSharingViewCount() {
       queryClient.invalidateQueries({
         queryKey: ['sharing', 'detail', postId],
       });
+    },
+  });
+}
+
+export function useDeleteSharingComment(postId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (commentId: number) => servDeleteSharingComment(commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['sharing', 'detail', postId],
+      });
+      toast.success('댓글이 삭제되었습니다.');
+    },
+    onError: (error) => {
+      toast.error(`댓글 삭제 실패: ${error.message}`);
     },
   });
 }


### PR DESCRIPTION
## 작업 내용
  - 교환/나눔 게시판 (장난감 교환)에 댓글 삭제 기능 추가 (게시판과 동일 패턴)                                                                                                                                          
  - 서버 측 작성자 검증 (`user_id` 매칭) 포함
  - 삭제 성공/실패 toast 피드백 제공     