### PR TITLE
feat: 교환/나눔 게시글 좋아요 기능 추가

### DIFF
--- a/src/__tests__/components/LikeButton.test.tsx
+++ b/src/__tests__/components/LikeButton.test.tsx
@@ -1,0 +1,135 @@
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders, screen, waitFor } from '../test-utils';
+import { createClient } from '@/libs/supabase/client';
+import { LikeButton } from '@/components/common/LikeButton';
+import { createMockUser, createMockProfile } from '../mocks/supabase';
+import type { MockSupabaseClient } from '../mocks/supabase';
+
+const mockPush = vi.fn();
+
+vi.mocked(await import('next/navigation')).useRouter.mockReturnValue({
+  push: mockPush,
+  back: vi.fn(),
+  replace: vi.fn(),
+  refresh: vi.fn(),
+  prefetch: vi.fn(),
+  forward: vi.fn(),
+});
+
+const mockSupabase = createClient() as unknown as MockSupabaseClient;
+
+function setupUnauthenticated() {
+  mockSupabase.auth = {
+    getUser: vi.fn(() =>
+      Promise.resolve({ data: { user: null }, error: null })
+    ),
+    onAuthStateChange: vi.fn(() => ({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    })),
+  } as typeof mockSupabase.auth;
+}
+
+function setupAuthenticated() {
+  const mockUser = createMockUser();
+  const mockProfile = createMockProfile();
+
+  mockSupabase.auth = {
+    getUser: vi.fn(() =>
+      Promise.resolve({ data: { user: mockUser }, error: null })
+    ),
+    onAuthStateChange: vi.fn(() => ({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    })),
+  } as typeof mockSupabase.auth;
+
+  mockSupabase.from = vi.fn(() => ({
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn(() =>
+          Promise.resolve({ data: mockProfile, error: null })
+        ),
+        then: vi.fn((cb: (val: { data: { post_id: number }[]; error: null }) => void) =>
+          cb({ data: [], error: null })
+        ),
+      }),
+    }),
+  })) as ReturnType<typeof vi.fn>;
+
+  mockSupabase.rpc = vi.fn(() =>
+    Promise.resolve({ data: true, error: null })
+  ) as ReturnType<typeof vi.fn>;
+}
+
+describe('LikeButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('하트 아이콘과 좋아요 카운트를 표시한다', () => {
+    setupUnauthenticated();
+
+    renderWithProviders(
+      <LikeButton postId={1} likeCount={5} />
+    );
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '좋아요' })).toBeInTheDocument();
+  });
+
+  it('좋아요 카운트가 0일 때도 표시한다', () => {
+    setupUnauthenticated();
+
+    renderWithProviders(
+      <LikeButton postId={1} likeCount={0} />
+    );
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+
+  it('비인증 사용자가 클릭하면 /signin으로 이동한다', async () => {
+    setupUnauthenticated();
+
+    const user = userEvent.setup();
+    renderWithProviders(
+      <LikeButton postId={1} likeCount={3} />
+    );
+
+    await user.click(screen.getByRole('button', { name: '좋아요' }));
+
+    expect(mockPush).toHaveBeenCalledWith('/signin');
+  });
+
+  it('인증된 사용자가 클릭하면 /signin으로 이동하지 않는다', async () => {
+    setupAuthenticated();
+
+    const user = userEvent.setup();
+    renderWithProviders(
+      <LikeButton postId={42} likeCount={3} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /좋아요/ }));
+
+    expect(mockPush).not.toHaveBeenCalledWith('/signin');
+  });
+
+  it('stopPropagation으로 부모 클릭 이벤트를 차단한다', async () => {
+    setupUnauthenticated();
+
+    const parentClick = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <div onClick={parentClick}>
+        <LikeButton postId={1} likeCount={0} />
+      </div>
+    );
+
+    await user.click(screen.getByRole('button', { name: '좋아요' }));
+
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/mocks/factories.ts
+++ b/src/__tests__/mocks/factories.ts
@@ -22,6 +22,7 @@ export function createMockSharingPost(
     exchange_option: '교환',
     tags: ['레고', '장난감'],
     views: 10,
+    like_count: 0,
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',
     profiles: DEFAULT_PROFILE,

--- a/src/__tests__/services/likes-services.test.ts
+++ b/src/__tests__/services/likes-services.test.ts
@@ -1,0 +1,157 @@
+import { createClient } from '@/libs/supabase/client';
+import {
+  servFetchUserLikedPostIds,
+  servToggleLike,
+  servFetchUserLikedSharingPosts,
+} from '@/services/likes/likes-services';
+import { createMockUser } from '../mocks/supabase';
+import { createMockSharingPost } from '../mocks/factories';
+import type { MockSupabaseClient } from '../mocks/supabase';
+
+const mockSupabase = createClient() as unknown as MockSupabaseClient;
+
+describe('servFetchUserLikedPostIds', () => {
+  it('인증된 사용자의 좋아요 post ID 배열을 반환한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    const eqMock = vi.fn(() =>
+      Promise.resolve({
+        data: [{ post_id: 1 }, { post_id: 3 }, { post_id: 5 }],
+        error: null,
+      })
+    );
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: eqMock,
+      })),
+    })) as ReturnType<typeof vi.fn>;
+
+    const result = await servFetchUserLikedPostIds();
+
+    expect(result).toEqual([1, 3, 5]);
+    expect(mockSupabase.from).toHaveBeenCalledWith('sharing_likes');
+  });
+
+  it('비인증 사용자는 빈 배열을 반환한다', async () => {
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: null }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    const result = await servFetchUserLikedPostIds();
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('servToggleLike', () => {
+  it('RPC toggle_like를 호출하고 결과를 반환한다', async () => {
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: true, error: null })
+    ) as ReturnType<typeof vi.fn>;
+
+    const result = await servToggleLike(42);
+
+    expect(result).toBe(true);
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('toggle_like', {
+      target_table: 'sharing',
+      target_post_id: 42,
+    });
+  });
+
+  it('에러 발생 시 예외를 던진다', async () => {
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: null, error: { message: 'RPC error' } })
+    ) as ReturnType<typeof vi.fn>;
+
+    await expect(servToggleLike(1)).rejects.toThrow();
+  });
+});
+
+describe('servFetchUserLikedSharingPosts', () => {
+  it('좋아요한 교환/나눔 게시글을 반환한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    const mockPosts = [
+      createMockSharingPost({ id: 1, title: '좋아요 게시글' }),
+    ];
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() =>
+              Promise.resolve({
+                data: [{ post_id: 1 }],
+                error: null,
+              })
+            ),
+          })),
+        };
+      }
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn(() => ({
+            order: vi.fn(() =>
+              Promise.resolve({ data: mockPosts, error: null })
+            ),
+          })),
+        })),
+      };
+    }) as ReturnType<typeof vi.fn>;
+
+    const result = await servFetchUserLikedSharingPosts();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.title).toBe('좋아요 게시글');
+  });
+
+  it('좋아요가 없으면 빈 배열을 반환한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() =>
+          Promise.resolve({
+            data: [],
+            error: null,
+          })
+        ),
+      })),
+    })) as ReturnType<typeof vi.fn>;
+
+    const result = await servFetchUserLikedSharingPosts();
+
+    expect(result).toEqual([]);
+  });
+
+  it('비인증 사용자는 빈 배열을 반환한다', async () => {
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: null }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    const result = await servFetchUserLikedSharingPosts();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/app/my-shop/components/MyShopContents.tsx
+++ b/src/app/my-shop/components/MyShopContents.tsx
@@ -9,7 +9,9 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { LoadingState } from '@/components/common/LoadingState';
 import { EmptyState } from '@/components/common/EmptyState';
 import { EditProfileDialog } from '@/components/my-shop/EditProfileDialog';
+import { LikeButton } from '@/components/common/LikeButton';
 import { useSharingList, useIncrementSharingViewCount } from '@/services/sharing/useSharing';
+import { useUserLikedSharingPosts } from '@/services/likes/useLikes';
 import type { User } from '@supabase/supabase-js';
 import type { Profile } from '@/services/auth/auth.types';
 
@@ -22,6 +24,8 @@ export default function MyShopContents({ user, profile }: MyShopContentsProps) {
   const router = useRouter();
   const { data: allPosts, isLoading } = useSharingList();
   const incrementView = useIncrementSharingViewCount();
+  const { data: likedSharingPosts, isLoading: isLoadingLikedSharing } =
+    useUserLikedSharingPosts();
 
   const myPosts = allPosts?.filter((post) => post.user_id === user.id);
 
@@ -99,7 +103,44 @@ export default function MyShopContents({ user, profile }: MyShopContentsProps) {
         </TabsContent>
 
         <TabsContent value="wishlist" className="pt-6">
-          <EmptyState message="준비중입니다." className="py-8" />
+          {isLoadingLikedSharing && <LoadingState height="sm" />}
+
+          {likedSharingPosts && likedSharingPosts.length > 0 ? (
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+              {likedSharingPosts.map((post) => (
+                <div
+                  key={post.id}
+                  className="flex cursor-pointer flex-col gap-2"
+                  onClick={() => {
+                    incrementView.mutate(post.id);
+                    router.push(`/sharing/${post.id}`);
+                  }}
+                >
+                  <div className="relative aspect-square overflow-hidden rounded-md">
+                    <Image
+                      src={post.image_url || '/images/도담덕로고.png'}
+                      alt={post.title}
+                      fill
+                      className="object-cover"
+                      unoptimized
+                    />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <p className="truncate text-sm">{post.title}</p>
+                    <LikeButton
+                      postId={post.id}
+                      likeCount={post.like_count}
+                      size="sm"
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            !isLoadingLikedSharing && (
+              <EmptyState message="좋아요한 게시글이 없습니다." className="py-8" />
+            )
+          )}
         </TabsContent>
       </Tabs>
       </div>

--- a/src/app/my-shop/page.tsx
+++ b/src/app/my-shop/page.tsx
@@ -4,6 +4,8 @@ import getQueryClient from '@/libs/query/query-client';
 import { createClient } from '@/libs/supabase/server';
 import { sharingQueries } from '@/services/sharing/queries';
 import { servFetchSharingPosts } from '@/services/sharing/sharing-services';
+import { likesQueries } from '@/services/likes/queries';
+import { servFetchUserLikedSharingPosts } from '@/services/likes/likes-services';
 import type { Profile } from '@/services/auth/auth.types';
 import MyShopContents from './components/MyShopContents';
 
@@ -29,6 +31,10 @@ export default async function MyShopPage() {
       .select('*')
       .eq('id', user.id)
       .single<Profile>(),
+    queryClient.prefetchQuery({
+      ...likesQueries.userLikedSharingPosts(),
+      queryFn: () => servFetchUserLikedSharingPosts(supabase),
+    }),
   ]);
 
   return (

--- a/src/app/sharing/[id]/components/SharingDetailContents.tsx
+++ b/src/app/sharing/[id]/components/SharingDetailContents.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
 import { Trash2, MessageCircle } from 'lucide-react';
+import { LikeButton } from '@/components/common/LikeButton';
 import { Card, CardContent, CardHeader, CardFooter } from '@/components/ui/card';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
@@ -153,9 +154,15 @@ export default function SharingDetailContents() {
                     />
                   )}
                 </div>
-                <p className="text-xs text-muted-foreground">
-                  조회 {post.views}
-                </p>
+                <div className="flex items-center gap-2">
+                  <p className="text-xs text-muted-foreground">
+                    조회 {post.views}
+                  </p>
+                  <LikeButton
+                    postId={post.id}
+                    likeCount={post.like_count}
+                  />
+                </div>
               </div>
 
               <p className="whitespace-pre-wrap">{post.content}</p>

--- a/src/app/sharing/[id]/page.tsx
+++ b/src/app/sharing/[id]/page.tsx
@@ -3,6 +3,8 @@ import getQueryClient from '@/libs/query/query-client';
 import { createClient } from '@/libs/supabase/server';
 import { sharingQueries } from '@/services/sharing/queries';
 import { servFetchSharingDetail } from '@/services/sharing/sharing-services';
+import { likesQueries } from '@/services/likes/queries';
+import { servFetchUserLikedPostIds } from '@/services/likes/likes-services';
 import SharingDetailContents from './components/SharingDetailContents';
 
 interface SharingDetailPageProps {
@@ -17,10 +19,27 @@ export default async function SharingDetailPage({
   const queryClient = getQueryClient();
   const supabase = await createClient();
 
-  await queryClient.prefetchQuery({
-    ...sharingQueries.detail(postId),
-    queryFn: () => servFetchSharingDetail(postId, supabase),
-  });
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const prefetches = [
+    queryClient.prefetchQuery({
+      ...sharingQueries.detail(postId),
+      queryFn: () => servFetchSharingDetail(postId, supabase),
+    }),
+  ];
+
+  if (user) {
+    prefetches.push(
+      queryClient.prefetchQuery({
+        ...likesQueries.userLikedIds(),
+        queryFn: () => servFetchUserLikedPostIds(supabase),
+      })
+    );
+  }
+
+  await Promise.all(prefetches);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/sharing/components/SharingContents.tsx
+++ b/src/app/sharing/components/SharingContents.tsx
@@ -10,6 +10,7 @@ import { LoadingState } from '@/components/common/LoadingState';
 import { EmptyState } from '@/components/common/EmptyState';
 import { PageHeader } from '@/components/common/PageHeader';
 import { FloatingActionButton } from '@/components/common/FloatingActionButton';
+import { LikeButton } from '@/components/common/LikeButton';
 import {
   useSharingList,
   useSharingSearch,
@@ -102,7 +103,14 @@ export default function SharingContents() {
 
               <div className="flex flex-col gap-2 p-3">
                 <div className="flex flex-col gap-1">
-                  <p className="truncate text-sm font-semibold">{post.title}</p>
+                  <div className="flex items-center justify-between">
+                    <p className="truncate text-sm font-semibold">{post.title}</p>
+                    <LikeButton
+                      postId={post.id}
+                      likeCount={post.like_count}
+                      size="sm"
+                    />
+                  </div>
                   <p className="text-xs text-muted-foreground">
                     {post.location} · {formatTimeSince(post.created_at)} · 조회{' '}
                     {post.views}

--- a/src/components/common/LikeButton.tsx
+++ b/src/components/common/LikeButton.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Heart } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useIsLiked, useToggleLike } from '@/services/likes/useLikes';
+import { useUser } from '@/services/auth/useUser';
+import { cn } from '@/lib/utils';
+
+interface LikeButtonProps {
+  postId: number;
+  likeCount: number;
+  size?: 'sm' | 'default';
+}
+
+export function LikeButton({
+  postId,
+  likeCount,
+  size = 'default',
+}: LikeButtonProps) {
+  const router = useRouter();
+  const { user } = useUser();
+  const isLiked = useIsLiked(postId);
+  const toggleLike = useToggleLike();
+
+  function handleClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (!user) {
+      router.push('/signin');
+      return;
+    }
+
+    toggleLike.mutate(postId);
+  }
+
+  const iconSize = size === 'sm' ? 14 : 18;
+
+  return (
+    <Button
+      variant="ghost"
+      size={size === 'sm' ? 'icon-sm' : 'sm'}
+      className={cn(
+        'gap-1',
+        isLiked && 'text-red-500 hover:text-red-600'
+      )}
+      onClick={handleClick}
+      aria-label={isLiked ? '좋아요 취소' : '좋아요'}
+    >
+      <Heart
+        size={iconSize}
+        className={cn(isLiked && 'fill-current')}
+      />
+      <span className="text-xs">{likeCount}</span>
+    </Button>
+  );
+}

--- a/src/components/common/LikeButton.tsx
+++ b/src/components/common/LikeButton.tsx
@@ -32,6 +32,8 @@ export function LikeButton({
       return;
     }
 
+    if (toggleLike.isPending) return;
+
     toggleLike.mutate(postId);
   }
 

--- a/src/services/likes/likes-services.ts
+++ b/src/services/likes/likes-services.ts
@@ -1,0 +1,65 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@/libs/supabase/client';
+import type { Database } from '@/types/supabase';
+import type { SharingPost } from '@/services/sharing/sharing.types';
+
+export async function servFetchUserLikedPostIds(
+  client?: SupabaseClient<Database>
+): Promise<number[]> {
+  const supabase = client ?? createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from('sharing_likes')
+    .select('post_id')
+    .eq('user_id', user.id);
+
+  if (error) throw error;
+  return (data ?? []).map((row) => row.post_id);
+}
+
+export async function servToggleLike(postId: number): Promise<boolean> {
+  const supabase = createClient();
+
+  const { data, error } = await supabase.rpc('toggle_like', {
+    target_table: 'sharing',
+    target_post_id: postId,
+  });
+
+  if (error) throw error;
+  return data as boolean;
+}
+
+export async function servFetchUserLikedSharingPosts(
+  client?: SupabaseClient<Database>
+): Promise<SharingPost[]> {
+  const supabase = client ?? createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  const { data: likes, error: likesError } = await supabase
+    .from('sharing_likes')
+    .select('post_id')
+    .eq('user_id', user.id);
+
+  if (likesError) throw likesError;
+
+  const postIds = (likes ?? []).map((row) => row.post_id);
+  if (postIds.length === 0) return [];
+
+  const { data: posts, error: postsError } = await supabase
+    .from('sharing_posts')
+    .select('*, profiles(username, display_name, profile_url)')
+    .in('id', postIds)
+    .order('created_at', { ascending: false });
+
+  if (postsError) throw postsError;
+  return posts as SharingPost[];
+}

--- a/src/services/likes/queries.ts
+++ b/src/services/likes/queries.ts
@@ -1,0 +1,23 @@
+import { queryOptions } from '@tanstack/react-query';
+import {
+  servFetchUserLikedPostIds,
+  servFetchUserLikedSharingPosts,
+} from './likes-services';
+
+export const likesQueries = {
+  userLikedIds: () =>
+    queryOptions({
+      queryKey: ['likes', 'userIds'] as const,
+      queryFn: () => servFetchUserLikedPostIds(),
+      staleTime: 5 * 60 * 1000,
+      gcTime: 30 * 60 * 1000,
+    }),
+
+  userLikedSharingPosts: () =>
+    queryOptions({
+      queryKey: ['likes', 'userPosts', 'sharing'] as const,
+      queryFn: () => servFetchUserLikedSharingPosts(),
+      staleTime: 5 * 60 * 1000,
+      gcTime: 30 * 60 * 1000,
+    }),
+};

--- a/src/services/likes/useLikes.ts
+++ b/src/services/likes/useLikes.ts
@@ -1,0 +1,98 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { likesQueries } from './queries';
+import { servToggleLike } from './likes-services';
+import { useUser } from '@/services/auth/useUser';
+import type { SharingPost, SharingDetailResponse } from '@/services/sharing/sharing.types';
+
+export function useUserLikedIds() {
+  const { user } = useUser();
+
+  return useQuery({
+    ...likesQueries.userLikedIds(),
+    enabled: !!user,
+  });
+}
+
+export function useIsLiked(postId: number) {
+  const { data: likedIds } = useUserLikedIds();
+  return likedIds?.includes(postId) ?? false;
+}
+
+export function useToggleLike() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: number) => servToggleLike(postId),
+    onMutate: async (postId) => {
+      await queryClient.cancelQueries({
+        queryKey: likesQueries.userLikedIds().queryKey,
+      });
+
+      const previousIds = queryClient.getQueryData<number[]>(
+        likesQueries.userLikedIds().queryKey
+      );
+
+      const wasLiked = previousIds?.includes(postId) ?? false;
+      const delta = wasLiked ? -1 : 1;
+
+      queryClient.setQueryData<number[]>(
+        likesQueries.userLikedIds().queryKey,
+        (old) => {
+          if (!old) return wasLiked ? [] : [postId];
+          return wasLiked
+            ? old.filter((id) => id !== postId)
+            : [...old, postId];
+        }
+      );
+
+      queryClient.setQueriesData<SharingPost[]>(
+        { queryKey: ['sharing', 'list'] },
+        (old) =>
+          old?.map((post) =>
+            post.id === postId
+              ? { ...post, like_count: Math.max(0, post.like_count + delta) }
+              : post
+          )
+      );
+
+      queryClient.setQueriesData<SharingDetailResponse>(
+        { queryKey: ['sharing', 'detail', postId] },
+        (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            post: {
+              ...old.post,
+              like_count: Math.max(0, old.post.like_count + delta),
+            },
+          };
+        }
+      );
+
+      return { previousIds };
+    },
+    onError: (_err, _postId, context) => {
+      if (context?.previousIds !== undefined) {
+        queryClient.setQueryData(
+          likesQueries.userLikedIds().queryKey,
+          context.previousIds
+        );
+      }
+      queryClient.invalidateQueries({ queryKey: ['sharing', 'list'] });
+      queryClient.invalidateQueries({ queryKey: ['sharing', 'detail'] });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['likes'] });
+      queryClient.invalidateQueries({ queryKey: ['sharing', 'list'] });
+    },
+  });
+}
+
+export function useUserLikedSharingPosts() {
+  const { user } = useUser();
+
+  return useQuery({
+    ...likesQueries.userLikedSharingPosts(),
+    enabled: !!user,
+  });
+}

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -47,6 +47,7 @@ export interface Database {
           exchange_option: string;
           tags: string[];
           views: number;
+          like_count: number;
           created_at: string;
           updated_at: string;
         };
@@ -59,6 +60,7 @@ export interface Database {
           exchange_option?: string;
           tags?: string[];
           views?: number;
+          like_count?: number;
           created_at?: string;
           updated_at?: string;
         };
@@ -70,11 +72,45 @@ export interface Database {
           exchange_option?: string;
           tags?: string[];
           views?: number;
+          like_count?: number;
           updated_at?: string;
         };
         Relationships: [
           {
             foreignKeyName: 'sharing_posts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'profiles';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      sharing_likes: {
+        Row: {
+          id: number;
+          post_id: number;
+          user_id: string;
+          created_at: string;
+        };
+        Insert: {
+          post_id: number;
+          user_id: string;
+          created_at?: string;
+        };
+        Update: {
+          post_id?: number;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'sharing_likes_post_id_fkey';
+            columns: ['post_id'];
+            isOneToOne: false;
+            referencedRelation: 'sharing_posts';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'sharing_likes_user_id_fkey';
             columns: ['user_id'];
             isOneToOne: false;
             referencedRelation: 'profiles';
@@ -295,6 +331,10 @@ export interface Database {
       search_sharing_posts: {
         Args: { search_query: string };
         Returns: Database['public']['Tables']['sharing_posts']['Row'][];
+      };
+      toggle_like: {
+        Args: { target_table: string; target_post_id: number };
+        Returns: boolean;
       };
     };
     Enums: Record<string, never>;


### PR DESCRIPTION
  작업 내용                                                                                                                                                                                              

  - 교환/나눔 게시글에 좋아요(하트) 토글 기능 추가
  - 게시글 목록 카드와 상세 페이지에 LikeButton 배치
  - 마이페이지 하트목록 탭에 좋아요한 게시글 목록 표시 (기존 "준비중입니다" 대체)
  - 낙관적 업데이트로 즉각적인 UI 피드백 제공
  - 인증된 사용자의 좋아요 ID를 서버에서 프리페칭