### PR TITLE
test: 테스트 커버리지 보강 및 커버리지 측정 환경 구성 (104 → 178 tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ next-env.d.ts
 CLAUDE.md
 DESIGN.md
 REVIEW.md
+DESIGN-PLAN.md
+TODO.md
 
 # OS
 Thumbs.db

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
+    "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.9",
     "jsdom": "^29.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.9
+        version: 4.1.9(vitest@4.1.9)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
@@ -131,7 +134,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
 packages:
 
@@ -332,6 +335,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -1451,6 +1458,15 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/coverage-v8@4.1.9':
+    resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.9
+      vitest: 4.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
@@ -1597,6 +1613,9 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -2404,6 +2423,9 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -2655,6 +2677,18 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -2665,6 +2699,9 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2859,6 +2896,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -4191,6 +4235,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -5108,6 +5154,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
 
+  '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.9
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+
   '@vitest/expect@4.1.9':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -5286,6 +5346,12 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -6266,6 +6332,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-escaper@2.0.2: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -6477,6 +6545,19 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -6489,6 +6570,8 @@ snapshots:
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -6664,6 +6747,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   math-intrinsics@1.1.0: {}
 
@@ -7682,7 +7775,7 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.22.4
 
-  vitest@4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)):
+  vitest@4.1.9(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
@@ -7706,6 +7799,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.0.0
+      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw

--- a/src/__tests__/components/CommentSection.test.tsx
+++ b/src/__tests__/components/CommentSection.test.tsx
@@ -1,0 +1,126 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../test-utils';
+import { CommentSection } from '@/components/common/CommentSection';
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+const mockComments = [
+  {
+    id: 1,
+    user_id: 'user-1',
+    content: '교환 원합니다',
+    created_at: new Date().toISOString(),
+    profiles: { display_name: '유저1' },
+  },
+  {
+    id: 2,
+    user_id: 'user-2',
+    content: '좋은 장난감이네요',
+    created_at: new Date().toISOString(),
+    profiles: { display_name: '유저2' },
+  },
+];
+
+describe('CommentSection', () => {
+  it('댓글 목록을 렌더링한다', () => {
+    renderWithProviders(
+      <CommentSection
+        comments={mockComments}
+        isLoggedIn={false}
+        onSubmit={vi.fn()}
+        isSubmitting={false}
+      />
+    );
+
+    expect(screen.getByText('교환 원합니다')).toBeInTheDocument();
+    expect(screen.getByText('좋은 장난감이네요')).toBeInTheDocument();
+    expect(screen.getByText('유저1')).toBeInTheDocument();
+    expect(screen.getByText('유저2')).toBeInTheDocument();
+  });
+
+  it('댓글이 없으면 빈 상태 메시지를 표시한다', () => {
+    renderWithProviders(
+      <CommentSection
+        comments={[]}
+        isLoggedIn={false}
+        onSubmit={vi.fn()}
+        isSubmitting={false}
+      />
+    );
+
+    expect(screen.getByText('아직 댓글이 없습니다.')).toBeInTheDocument();
+  });
+
+  it('로그인 상태에서 입력 폼을 표시한다', () => {
+    renderWithProviders(
+      <CommentSection
+        comments={[]}
+        isLoggedIn={true}
+        onSubmit={vi.fn()}
+        isSubmitting={false}
+      />
+    );
+
+    expect(
+      screen.getByPlaceholderText('댓글을 입력해주세요.')
+    ).toBeInTheDocument();
+  });
+
+  it('비로그인 상태에서 입력 폼을 표시하지 않는다', () => {
+    renderWithProviders(
+      <CommentSection
+        comments={[]}
+        isLoggedIn={false}
+        onSubmit={vi.fn()}
+        isSubmitting={false}
+      />
+    );
+
+    expect(
+      screen.queryByPlaceholderText('댓글을 입력해주세요.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('댓글 입력 후 제출 시 onSubmit이 호출된다', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    renderWithProviders(
+      <CommentSection
+        comments={[]}
+        isLoggedIn={true}
+        onSubmit={onSubmit}
+        isSubmitting={false}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('댓글을 입력해주세요.');
+    await user.type(input, '새 댓글입니다');
+    await user.keyboard('{Enter}');
+
+    expect(onSubmit).toHaveBeenCalledWith('새 댓글입니다');
+  });
+
+  it('빈 댓글은 제출되지 않는다', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    renderWithProviders(
+      <CommentSection
+        comments={[]}
+        isLoggedIn={true}
+        onSubmit={onSubmit}
+        isSubmitting={false}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('댓글을 입력해주세요.');
+    await user.click(input);
+    await user.keyboard('{Enter}');
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/components/ConfirmDialog.test.tsx
+++ b/src/__tests__/components/ConfirmDialog.test.tsx
@@ -1,0 +1,99 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../test-utils';
+import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import { Button } from '@/components/ui/button';
+
+describe('ConfirmDialog', () => {
+  it('트리거를 렌더링한다', () => {
+    renderWithProviders(
+      <ConfirmDialog
+        trigger={<Button>삭제</Button>}
+        title="삭제 확인"
+        description="정말 삭제하시겠습니까?"
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('삭제')).toBeInTheDocument();
+  });
+
+  it('트리거 클릭 시 다이얼로그가 열린다', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <ConfirmDialog
+        trigger={<Button>삭제</Button>}
+        title="삭제 확인"
+        description="정말 삭제하시겠습니까?"
+        onConfirm={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByText('삭제'));
+
+    expect(screen.getByText('삭제 확인')).toBeInTheDocument();
+    expect(screen.getByText('정말 삭제하시겠습니까?')).toBeInTheDocument();
+  });
+
+  it('확인 버튼 클릭 시 onConfirm이 호출된다', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+
+    renderWithProviders(
+      <ConfirmDialog
+        trigger={<Button>삭제</Button>}
+        title="삭제 확인"
+        description="정말 삭제하시겠습니까?"
+        onConfirm={onConfirm}
+      />
+    );
+
+    await user.click(screen.getByText('삭제'));
+
+    const confirmButtons = screen.getAllByText('삭제');
+    const dialogConfirmButton = confirmButtons.find(
+      (btn) => btn.closest('[data-slot="dialog-content"]')
+    );
+    if (dialogConfirmButton) {
+      await user.click(dialogConfirmButton);
+    }
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('커스텀 confirmLabel을 표시한다', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <ConfirmDialog
+        trigger={<Button>실행</Button>}
+        title="확인"
+        description="실행하시겠습니까?"
+        confirmLabel="확인합니다"
+        onConfirm={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByText('실행'));
+
+    expect(screen.getByText('확인합니다')).toBeInTheDocument();
+  });
+
+  it('취소 버튼을 표시한다', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <ConfirmDialog
+        trigger={<Button>삭제</Button>}
+        title="삭제 확인"
+        description="정말 삭제하시겠습니까?"
+        onConfirm={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByText('삭제'));
+
+    expect(screen.getByText('취소')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/hooks/useAuth.test.ts
+++ b/src/__tests__/hooks/useAuth.test.ts
@@ -1,7 +1,23 @@
 import { createClient } from '@/libs/supabase/client';
 import { renderHookWithProviders, waitFor } from '../test-utils';
-import { useSignIn, useSignUp, useCheckUsername } from '@/services/auth/useAuth';
+import {
+  useSignIn,
+  useSignUp,
+  useSignOut,
+  useCheckUsername,
+  useUpdateProfile,
+  useUpdateProfileImage,
+} from '@/services/auth/useAuth';
+import { createMockUser } from '../mocks/supabase';
 import type { MockSupabaseClient } from '../mocks/supabase';
+
+vi.mock('@/libs/supabase/storage', () => ({
+  uploadImage: vi.fn(() =>
+    Promise.resolve('https://test.supabase.co/storage/new-profile.jpg')
+  ),
+  extractStoragePath: vi.fn(() => 'old-path.jpg'),
+  deleteImage: vi.fn(() => Promise.resolve()),
+}));
 
 
 const mockSupabase = createClient() as unknown as MockSupabaseClient;
@@ -64,5 +80,91 @@ describe('useCheckUsername', () => {
     const { result } = renderHookWithProviders(() => useCheckUsername(''));
 
     expect(result.current.isFetching).toBe(false);
+  });
+});
+
+describe('useSignOut', () => {
+  it('로그아웃 mutation이 성공한다', async () => {
+    mockSupabase.auth.signOut = vi.fn(() =>
+      Promise.resolve({ error: null })
+    );
+
+    const { result } = renderHookWithProviders(() => useSignOut());
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});
+
+describe('useUpdateProfile', () => {
+  it('프로필 업데이트 mutation이 성공한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn(() => Promise.resolve({ error: null })),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useUpdateProfile());
+
+    result.current.mutate({
+      display_name: '새이름',
+      location: '서울특별시',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});
+
+describe('useUpdateProfileImage', () => {
+  it('프로필 이미지 업데이트 mutation이 성공한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn(() =>
+                Promise.resolve({ data: { profile_url: '' }, error: null })
+              ),
+            }),
+          }),
+        };
+      }
+      return {
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn(() => Promise.resolve({ error: null })),
+        }),
+      };
+    }) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useUpdateProfileImage());
+
+    result.current.mutate(
+      new File(['test'], 'photo.jpg', { type: 'image/jpeg' })
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
   });
 });

--- a/src/__tests__/hooks/useBoard.test.ts
+++ b/src/__tests__/hooks/useBoard.test.ts
@@ -1,8 +1,23 @@
 import { createClient } from '@/libs/supabase/client';
 import { renderHookWithProviders, waitFor } from '../test-utils';
-import { useBoardList } from '@/services/board/useBoard';
-import { createMockBoardPost } from '../mocks/factories';
+import {
+  useBoardList,
+  useBoardDetail,
+  useCreateBoardPost,
+  useDeleteBoardPost,
+  useAddBoardComment,
+  useDeleteBoardComment,
+  useIncrementBoardViewCount,
+} from '@/services/board/useBoard';
+import { createMockBoardPost, createMockBoardDetail } from '../mocks/factories';
+import { createMockUser } from '../mocks/supabase';
 import type { MockSupabaseClient } from '../mocks/supabase';
+
+vi.mock('@/libs/supabase/storage', () => ({
+  uploadImage: vi.fn(() =>
+    Promise.resolve('https://test.supabase.co/storage/uploaded.jpg')
+  ),
+}));
 
 
 const mockSupabase = createClient() as unknown as MockSupabaseClient;
@@ -30,5 +45,167 @@ describe('useBoardList', () => {
 
     expect(result.current.data).toHaveLength(2);
     expect(result.current.data![0]!.title).toBe('육아 꿀팁');
+  });
+});
+
+describe('useBoardDetail', () => {
+  it('게시글 상세를 가져온다', async () => {
+    const mockDetail = createMockBoardDetail();
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn(() =>
+                Promise.resolve({ data: mockDetail.post, error: null })
+              ),
+            }),
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn(() =>
+              Promise.resolve({ data: mockDetail.comments, error: null })
+            ),
+          }),
+        }),
+      };
+    }) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useBoardDetail(1));
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data!.post.title).toBe('육아 꿀팁 공유');
+  });
+});
+
+describe('useCreateBoardPost', () => {
+  it('게시글 생성 mutation이 성공한다', async () => {
+    const mockUser = createMockUser();
+    const mockPost = createMockBoardPost({ title: '새 게시글' });
+
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn(() =>
+            Promise.resolve({ data: mockPost, error: null })
+          ),
+        }),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useCreateBoardPost());
+
+    result.current.mutate({
+      title: '새 게시글',
+      content: '내용입니다',
+      image: new File(['test'], 'test.jpg', { type: 'image/jpeg' }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});
+
+describe('useDeleteBoardPost', () => {
+  it('게시글 삭제 mutation이 성공한다', async () => {
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn().mockReturnValue({
+        eq: vi.fn(() => Promise.resolve({ error: null })),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useDeleteBoardPost());
+
+    result.current.mutate(1);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});
+
+describe('useAddBoardComment', () => {
+  it('댓글 추가 mutation이 성공한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      insert: vi.fn(() => Promise.resolve({ error: null })),
+    })) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useAddBoardComment());
+
+    result.current.mutate({ postId: 1, content: '좋은 정보네요' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});
+
+describe('useDeleteBoardComment', () => {
+  it('댓글 삭제 mutation이 성공한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => Promise.resolve({ error: null, count: 1 })),
+        })),
+      })),
+    })) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() =>
+      useDeleteBoardComment(1)
+    );
+
+    result.current.mutate(1);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});
+
+describe('useIncrementBoardViewCount', () => {
+  it('조회수 증가 mutation이 성공한다', async () => {
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: null, error: null })
+    ) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() =>
+      useIncrementBoardViewCount()
+    );
+
+    result.current.mutate(1);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
   });
 });

--- a/src/__tests__/hooks/useChat.test.ts
+++ b/src/__tests__/hooks/useChat.test.ts
@@ -4,6 +4,7 @@ import {
   useChatList,
   useChatMessages,
   useSendMessage,
+  useCreateChatRoom,
 } from '@/services/chat/useChat';
 import { createMockChatRoom, createMockChatMessage } from '../mocks/factories';
 import type { MockSupabaseClient } from '../mocks/supabase';
@@ -99,6 +100,46 @@ describe('useSendMessage', () => {
     const { result } = renderHookWithProviders(() => useSendMessage());
 
     result.current.mutate({ roomId: 1, message: '테스트 메시지' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});
+
+describe('useCreateChatRoom', () => {
+  it('채팅방 생성 mutation이 성공한다', async () => {
+    const mockRoom = createMockChatRoom();
+
+    mockSupabase.auth.getUser = vi.fn(() =>
+      Promise.resolve({
+        data: { user: { id: 'test-uuid-1' } },
+        error: null,
+      })
+    );
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn(() =>
+              Promise.resolve({ data: null, error: null })
+            ),
+          }),
+        }),
+      }),
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn(() =>
+            Promise.resolve({ data: mockRoom, error: null })
+          ),
+        }),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useCreateChatRoom());
+
+    result.current.mutate({ otherUserId: 'test-uuid-2', postId: 1 });
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);

--- a/src/__tests__/hooks/useLikes.test.tsx
+++ b/src/__tests__/hooks/useLikes.test.tsx
@@ -1,0 +1,222 @@
+import { createClient } from '@/libs/supabase/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { renderHookWithProviders } from '../test-utils';
+import {
+  useUserLikedIds,
+  useIsLiked,
+  useToggleLike,
+  useUserLikedSharingPosts,
+} from '@/services/likes/useLikes';
+import type { MockSupabaseClient } from '../mocks/supabase';
+
+const mockSupabase = createClient() as unknown as MockSupabaseClient;
+
+function setupAuthenticatedUser() {
+  mockSupabase.auth = {
+    getUser: vi.fn(() =>
+      Promise.resolve({
+        data: { user: { id: 'test-uuid-1', email: 'test@example.com' } },
+        error: null,
+      })
+    ),
+    onAuthStateChange: vi.fn(() => ({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    })),
+  } as typeof mockSupabase.auth;
+}
+
+function setupUnauthenticatedUser() {
+  mockSupabase.auth = {
+    getUser: vi.fn(() =>
+      Promise.resolve({ data: { user: null }, error: null })
+    ),
+    onAuthStateChange: vi.fn(() => ({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    })),
+  } as typeof mockSupabase.auth;
+}
+
+function createSeededQueryClient(likedIds: number[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+  queryClient.setQueryData(['likes', 'userIds'], likedIds);
+  return queryClient;
+}
+
+describe('useUserLikedIds', () => {
+  it('비인증 사용자는 쿼리를 실행하지 않는다', () => {
+    setupUnauthenticatedUser();
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn(() =>
+            Promise.resolve({ data: null, error: null })
+          ),
+        }),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useUserLikedIds());
+
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  it('인증된 사용자의 좋아요 ID 목록을 가져온다', async () => {
+    setupAuthenticatedUser();
+
+    const profileEq = vi.fn().mockReturnValue({
+      single: vi.fn(() =>
+        Promise.resolve({
+          data: {
+            id: 'test-uuid-1',
+            username: 'test',
+            display_name: '테스트',
+            location: '광주',
+            profile_url: '',
+            level: 1,
+            verification_count: 0,
+            created_at: '',
+            updated_at: '',
+          },
+          error: null,
+        })
+      ),
+    });
+
+    const likesEq = vi.fn(() =>
+      Promise.resolve({
+        data: [{ post_id: 1 }, { post_id: 3 }],
+        error: null,
+      })
+    );
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({ eq: profileEq }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnValue({ eq: likesEq }),
+      };
+    }) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useUserLikedIds());
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual([1, 3]);
+  });
+});
+
+describe('useIsLiked', () => {
+  it('좋아요한 게시글이면 true를 반환한다', () => {
+    const queryClient = createSeededQueryClient([1, 3, 5]);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useIsLiked(3), { wrapper });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('좋아요하지 않은 게시글이면 false를 반환한다', () => {
+    const queryClient = createSeededQueryClient([1, 3, 5]);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useIsLiked(2), { wrapper });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('likedIds가 없으면 false를 반환한다', () => {
+    const { result } = renderHookWithProviders(() => useIsLiked(1));
+
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('useToggleLike', () => {
+  it('좋아요 토글 mutation이 성공한다', async () => {
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: true, error: null })
+    ) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useToggleLike());
+
+    result.current.mutate(1);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+
+  it('toggle_like RPC를 호출한다', async () => {
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: true, error: null })
+    ) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useToggleLike());
+
+    result.current.mutate(5);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('toggle_like', {
+      target_table: 'sharing',
+      target_post_id: 5,
+    });
+  });
+
+  it('mutation 실패 시 에러 상태가 된다', async () => {
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: null, error: { message: 'RPC error' } })
+    ) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useToggleLike());
+
+    result.current.mutate(1);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});
+
+describe('useUserLikedSharingPosts', () => {
+  it('비인증 사용자는 쿼리를 실행하지 않는다', () => {
+    setupUnauthenticatedUser();
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn(() =>
+            Promise.resolve({ data: null, error: null })
+          ),
+        }),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() =>
+      useUserLikedSharingPosts()
+    );
+
+    expect(result.current.isFetching).toBe(false);
+  });
+});

--- a/src/__tests__/hooks/useSharing.test.ts
+++ b/src/__tests__/hooks/useSharing.test.ts
@@ -2,11 +2,24 @@ import { createClient } from '@/libs/supabase/client';
 import { renderHookWithProviders, waitFor } from '../test-utils';
 import {
   useSharingList,
+  useSharingDetail,
   useSharingSearch,
   usePopularSearches,
+  useCreateSharingPost,
+  useDeleteSharingPost,
+  useAddSharingComment,
+  useDeleteSharingComment,
+  useIncrementSharingViewCount,
 } from '@/services/sharing/useSharing';
-import { createMockSharingPost } from '../mocks/factories';
+import { createMockSharingPost, createMockSharingDetail } from '../mocks/factories';
+import { createMockUser } from '../mocks/supabase';
 import type { MockSupabaseClient } from '../mocks/supabase';
+
+vi.mock('@/libs/supabase/storage', () => ({
+  uploadImage: vi.fn(() =>
+    Promise.resolve('https://test.supabase.co/storage/uploaded.jpg')
+  ),
+}));
 
 
 const mockSupabase = createClient() as unknown as MockSupabaseClient;
@@ -64,5 +77,171 @@ describe('usePopularSearches', () => {
 
     expect(result.current.data).toHaveLength(2);
     expect(result.current.data![0]!.query).toBe('레고');
+  });
+});
+
+describe('useSharingDetail', () => {
+  it('게시글 상세를 가져온다', async () => {
+    const mockDetail = createMockSharingDetail();
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn(() =>
+                Promise.resolve({ data: mockDetail.post, error: null })
+              ),
+            }),
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn(() =>
+              Promise.resolve({ data: mockDetail.comments, error: null })
+            ),
+          }),
+        }),
+      };
+    }) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useSharingDetail(1));
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data!.post.title).toBe('레고 교환합니다');
+    expect(result.current.data!.comments).toHaveLength(1);
+  });
+});
+
+describe('useCreateSharingPost', () => {
+  it('게시글 생성 mutation이 성공한다', async () => {
+    const mockUser = createMockUser();
+    const mockPost = createMockSharingPost({ title: '새 장난감' });
+
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn(() =>
+            Promise.resolve({ data: mockPost, error: null })
+          ),
+        }),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useCreateSharingPost());
+
+    result.current.mutate({
+      title: '새 장난감',
+      content: '상태 좋음',
+      location: '광주광역시',
+      exchangeOption: '교환',
+      tags: ['장난감'],
+      image: new File(['test'], 'test.jpg', { type: 'image/jpeg' }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});
+
+describe('useDeleteSharingPost', () => {
+  it('게시글 삭제 mutation이 성공한다', async () => {
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn().mockReturnValue({
+        eq: vi.fn(() => Promise.resolve({ error: null })),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useDeleteSharingPost());
+
+    result.current.mutate(1);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});
+
+describe('useAddSharingComment', () => {
+  it('댓글 추가 mutation이 성공한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      insert: vi.fn(() => Promise.resolve({ error: null })),
+    })) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() => useAddSharingComment());
+
+    result.current.mutate({ postId: 1, content: '좋은 장난감이네요' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});
+
+describe('useDeleteSharingComment', () => {
+  it('댓글 삭제 mutation이 성공한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => Promise.resolve({ error: null, count: 1 })),
+        })),
+      })),
+    })) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() =>
+      useDeleteSharingComment(1)
+    );
+
+    result.current.mutate(1);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+});
+
+describe('useIncrementSharingViewCount', () => {
+  it('조회수 증가 mutation이 성공한다', async () => {
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: null, error: null })
+    ) as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHookWithProviders(() =>
+      useIncrementSharingViewCount()
+    );
+
+    result.current.mutate(1);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
   });
 });

--- a/src/__tests__/libs/format-date.test.ts
+++ b/src/__tests__/libs/format-date.test.ts
@@ -1,4 +1,4 @@
-import { formatTimeSince } from '@/libs/format-date';
+import { formatTimeSince, formatDate, formatDateTime } from '@/libs/format-date';
 
 describe('formatTimeSince', () => {
   it('방금 생성된 날짜면 "방금 전"을 반환한다', () => {
@@ -26,5 +26,48 @@ describe('formatTimeSince', () => {
 
     const result = formatTimeSince(thirtyDaysAgo.toISOString());
     expect(result).toMatch(/^\d{4}\.\d{2}\.\d{2}$/);
+  });
+
+  it('30분 전이면 "30분 전"을 반환한다', () => {
+    const thirtyMinAgo = new Date();
+    thirtyMinAgo.setMinutes(thirtyMinAgo.getMinutes() - 30);
+
+    expect(formatTimeSince(thirtyMinAgo.toISOString())).toBe('30분 전');
+  });
+
+  it('5시간 전이면 "5시간 전"을 반환한다', () => {
+    const fiveHoursAgo = new Date();
+    fiveHoursAgo.setHours(fiveHoursAgo.getHours() - 5);
+
+    expect(formatTimeSince(fiveHoursAgo.toISOString())).toBe('5시간 전');
+  });
+});
+
+describe('formatDate', () => {
+  it('날짜를 YYYY.MM.DD 형식으로 반환한다', () => {
+    expect(formatDate('2024-01-15T10:30:00Z')).toMatch(/^\d{4}\.\d{2}\.\d{2}$/);
+  });
+
+  it('월과 일을 2자리로 패딩한다', () => {
+    const result = formatDate('2024-03-05T00:00:00Z');
+    const parts = result.split('.');
+    expect(parts[1]).toHaveLength(2);
+    expect(parts[2]).toHaveLength(2);
+  });
+});
+
+describe('formatDateTime', () => {
+  it('날짜와 시간을 YYYY.MM.DD HH:mm 형식으로 반환한다', () => {
+    expect(formatDateTime('2024-01-15T10:30:00Z')).toMatch(
+      /^\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}$/
+    );
+  });
+
+  it('시간과 분을 2자리로 패딩한다', () => {
+    const result = formatDateTime('2024-01-15T03:05:00Z');
+    const timePart = result.split(' ')[1]!;
+    const [hours, minutes] = timePart.split(':');
+    expect(hours).toHaveLength(2);
+    expect(minutes).toHaveLength(2);
   });
 });

--- a/src/__tests__/libs/image-utils.test.ts
+++ b/src/__tests__/libs/image-utils.test.ts
@@ -1,0 +1,83 @@
+import {
+  detectMimeType,
+  convertHeicToJpeg,
+  SUPPORTED_MIMES,
+  MAX_FILE_SIZE,
+} from '@/libs/image-utils';
+
+describe('SUPPORTED_MIMES', () => {
+  it('5종의 이미지 MIME 타입을 지원한다', () => {
+    expect(SUPPORTED_MIMES.size).toBe(5);
+    expect(SUPPORTED_MIMES.has('image/jpeg')).toBe(true);
+    expect(SUPPORTED_MIMES.has('image/png')).toBe(true);
+    expect(SUPPORTED_MIMES.has('image/gif')).toBe(true);
+    expect(SUPPORTED_MIMES.has('image/webp')).toBe(true);
+    expect(SUPPORTED_MIMES.has('image/heic')).toBe(true);
+  });
+});
+
+describe('MAX_FILE_SIZE', () => {
+  it('5MB로 설정되어 있다', () => {
+    expect(MAX_FILE_SIZE).toBe(5 * 1024 * 1024);
+  });
+});
+
+describe('detectMimeType', () => {
+  it('JPEG 매직바이트를 감지한다', () => {
+    const buffer = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]).buffer;
+    expect(detectMimeType(buffer)).toBe('image/jpeg');
+  });
+
+  it('PNG 매직바이트를 감지한다', () => {
+    const buffer = new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer;
+    expect(detectMimeType(buffer)).toBe('image/png');
+  });
+
+  it('GIF 매직바이트를 감지한다', () => {
+    const buffer = new Uint8Array([0x47, 0x49, 0x46, 0x38]).buffer;
+    expect(detectMimeType(buffer)).toBe('image/gif');
+  });
+
+  it('WebP 매직바이트를 감지한다', () => {
+    const buffer = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+    ]).buffer;
+    expect(detectMimeType(buffer)).toBe('image/webp');
+  });
+
+  it('HEIC ftyp 박스를 감지한다', () => {
+    const buffer = new Uint8Array([
+      0x00, 0x00, 0x00, 0x00, 0x66, 0x74, 0x79, 0x70,
+    ]).buffer;
+    expect(detectMimeType(buffer)).toBe('image/heic');
+  });
+
+  it('알 수 없는 포맷은 null을 반환한다', () => {
+    const buffer = new Uint8Array([0x00, 0x00, 0x00, 0x00]).buffer;
+    expect(detectMimeType(buffer)).toBeNull();
+  });
+
+  it('빈 버퍼는 null을 반환한다', () => {
+    const buffer = new Uint8Array([]).buffer;
+    expect(detectMimeType(buffer)).toBeNull();
+  });
+});
+
+vi.mock('heic2any', () => ({
+  default: vi.fn(() =>
+    Promise.resolve(new Blob(['converted'], { type: 'image/jpeg' }))
+  ),
+}));
+
+describe('convertHeicToJpeg', () => {
+  it('HEIC 파일을 JPEG로 변환한다', async () => {
+    const heicFile = new File(['heic-data'], 'photo.heic', {
+      type: 'image/heic',
+    });
+
+    const result = await convertHeicToJpeg(heicFile);
+
+    expect(result.name).toBe('photo.jpg');
+    expect(result.type).toBe('image/jpeg');
+  });
+});

--- a/src/__tests__/services/auth-services.test.ts
+++ b/src/__tests__/services/auth-services.test.ts
@@ -2,9 +2,22 @@ import { createClient } from '@/libs/supabase/client';
 import {
   servSignIn,
   servSignUp,
+  servSignOut,
   servCheckUsername,
+  servFetchCurrentProfile,
+  servUpdateProfile,
+  servUpdateProfileImage,
 } from '@/services/auth/auth-services';
+import { createMockUser, createMockProfile } from '../mocks/supabase';
 import type { MockSupabaseClient } from '../mocks/supabase';
+
+vi.mock('@/libs/supabase/storage', () => ({
+  uploadImage: vi.fn(() =>
+    Promise.resolve('https://test.supabase.co/storage/new-profile.jpg')
+  ),
+  extractStoragePath: vi.fn(() => 'old-path.jpg'),
+  deleteImage: vi.fn(() => Promise.resolve()),
+}));
 
 
 const mockSupabase = createClient() as unknown as MockSupabaseClient;
@@ -98,5 +111,197 @@ describe('servCheckUsername', () => {
 
     const result = await servCheckUsername('existinguser');
     expect(result.isAvailable).toBe(false);
+  });
+});
+
+describe('servSignOut', () => {
+  it('로그아웃에 성공한다', async () => {
+    mockSupabase.auth.signOut = vi.fn(() =>
+      Promise.resolve({ error: null })
+    );
+
+    await expect(servSignOut()).resolves.toBeUndefined();
+    expect(mockSupabase.auth.signOut).toHaveBeenCalled();
+  });
+
+  it('로그아웃 실패 시 에러를 던진다', async () => {
+    mockSupabase.auth.signOut = vi.fn(() =>
+      Promise.resolve({ error: { message: 'Sign out failed' } })
+    );
+
+    await expect(servSignOut()).rejects.toThrow();
+  });
+});
+
+describe('servFetchCurrentProfile', () => {
+  it('인증된 사용자의 프로필을 반환한다', async () => {
+    const mockUser = createMockUser();
+    const mockProfile = createMockProfile();
+
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn(() =>
+            Promise.resolve({ data: mockProfile, error: null })
+          ),
+        }),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    const result = await servFetchCurrentProfile();
+
+    expect(result).not.toBeNull();
+    expect(result!.user.id).toBe(mockUser.id);
+    expect(result!.profile.username).toBe('testuser');
+  });
+
+  it('미인증 사용자는 null을 반환한다', async () => {
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: null }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    const result = await servFetchCurrentProfile();
+    expect(result).toBeNull();
+  });
+});
+
+describe('servUpdateProfile', () => {
+  it('프로필을 업데이트한다', async () => {
+    const mockUser = createMockUser();
+
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn(() => Promise.resolve({ error: null })),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(
+      servUpdateProfile({
+        display_name: '새이름',
+        location: '서울특별시',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('미인증 사용자는 에러를 던진다', async () => {
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: null }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    await expect(
+      servUpdateProfile({
+        display_name: '새이름',
+        location: '서울',
+      })
+    ).rejects.toThrow('인증이 필요합니다');
+  });
+});
+
+describe('servUpdateProfileImage', () => {
+  it('프로필 이미지를 업데이트하고 URL을 반환한다', async () => {
+    const mockUser = createMockUser();
+
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    const eqForSelect = vi.fn().mockReturnValue({
+      single: vi.fn(() =>
+        Promise.resolve({ data: { profile_url: '' }, error: null })
+      ),
+    });
+
+    const eqForUpdate = vi.fn(() =>
+      Promise.resolve({ error: null })
+    );
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({ eq: eqForSelect }),
+        };
+      }
+      return {
+        update: vi.fn().mockReturnValue({ eq: eqForUpdate }),
+      };
+    }) as ReturnType<typeof vi.fn>;
+
+    const file = new File(['test'], 'photo.jpg', { type: 'image/jpeg' });
+    const result = await servUpdateProfileImage(file);
+
+    expect(result).toBe('https://test.supabase.co/storage/new-profile.jpg');
+  });
+
+  it('기존 프로필 이미지가 있으면 삭제를 시도한다', async () => {
+    const { deleteImage } = await import('@/libs/supabase/storage');
+    const mockUser = createMockUser();
+
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn(() =>
+                Promise.resolve({
+                  data: { profile_url: 'https://test.supabase.co/object/public/profile-images/old.jpg' },
+                  error: null,
+                })
+              ),
+            }),
+          }),
+        };
+      }
+      return {
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn(() => Promise.resolve({ error: null })),
+        }),
+      };
+    }) as ReturnType<typeof vi.fn>;
+
+    const file = new File(['test'], 'photo.jpg', { type: 'image/jpeg' });
+    await servUpdateProfileImage(file);
+
+    expect(deleteImage).toHaveBeenCalled();
+  });
+
+  it('미인증 사용자는 에러를 던진다', async () => {
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: null }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    const file = new File(['test'], 'photo.jpg', { type: 'image/jpeg' });
+    await expect(servUpdateProfileImage(file)).rejects.toThrow(
+      '인증이 필요합니다'
+    );
   });
 });

--- a/src/__tests__/services/board-services.test.ts
+++ b/src/__tests__/services/board-services.test.ts
@@ -1,7 +1,22 @@
 import { createClient } from '@/libs/supabase/client';
-import { servFetchBoardPosts } from '@/services/board/board-services';
-import { createMockBoardPost } from '../mocks/factories';
+import {
+  servFetchBoardPosts,
+  servFetchBoardDetail,
+  servCreateBoardPost,
+  servDeleteBoardPost,
+  servIncrementBoardViewCount,
+  servAddBoardComment,
+  servDeleteBoardComment,
+} from '@/services/board/board-services';
+import { createMockUser } from '../mocks/supabase';
+import { createMockBoardPost, createMockBoardDetail } from '../mocks/factories';
 import type { MockSupabaseClient } from '../mocks/supabase';
+
+vi.mock('@/libs/supabase/storage', () => ({
+  uploadImage: vi.fn(() =>
+    Promise.resolve('https://test.supabase.co/storage/uploaded.jpg')
+  ),
+}));
 
 
 const mockSupabase = createClient() as unknown as MockSupabaseClient;
@@ -37,5 +52,233 @@ describe('servFetchBoardPosts', () => {
     })) as ReturnType<typeof vi.fn>;
 
     await expect(servFetchBoardPosts()).rejects.toThrow();
+  });
+});
+
+describe('servFetchBoardDetail', () => {
+  it('게시글 상세 정보를 반환한다', async () => {
+    const mockDetail = createMockBoardDetail();
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn(() =>
+                Promise.resolve({ data: mockDetail.post, error: null })
+              ),
+            }),
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn(() =>
+              Promise.resolve({ data: mockDetail.comments, error: null })
+            ),
+          }),
+        }),
+      };
+    }) as ReturnType<typeof vi.fn>;
+
+    const result = await servFetchBoardDetail(1);
+
+    expect(result.post.title).toBe('육아 꿀팁 공유');
+    expect(result.comments).toHaveLength(0);
+  });
+
+  it('존재하지 않는 게시글이면 에러를 던진다', async () => {
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn(() =>
+            Promise.resolve({ data: null, error: { message: 'Not found' } })
+          ),
+        }),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(servFetchBoardDetail(999)).rejects.toThrow();
+  });
+});
+
+describe('servCreateBoardPost', () => {
+  it('게시글을 생성하고 반환한다', async () => {
+    const mockUser = createMockUser();
+    const mockPost = createMockBoardPost({ title: '새 게시글' });
+
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn(() =>
+            Promise.resolve({ data: mockPost, error: null })
+          ),
+        }),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    const result = await servCreateBoardPost({
+      title: '새 게시글',
+      content: '게시글 내용입니다',
+      image: new File(['test'], 'test.jpg', { type: 'image/jpeg' }),
+    });
+
+    expect(result.title).toBe('새 게시글');
+  });
+
+  it('미인증 사용자는 에러를 던진다', async () => {
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: null }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    await expect(
+      servCreateBoardPost({
+        title: '테스트',
+        content: '내용',
+        image: new File(['test'], 'test.jpg', { type: 'image/jpeg' }),
+      })
+    ).rejects.toThrow('인증이 필요합니다');
+  });
+});
+
+describe('servDeleteBoardPost', () => {
+  it('게시글을 삭제한다', async () => {
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn().mockReturnValue({
+        eq: vi.fn(() => Promise.resolve({ error: null })),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(servDeleteBoardPost(1)).resolves.toBeUndefined();
+  });
+
+  it('에러 발생 시 예외를 던진다', async () => {
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn().mockReturnValue({
+        eq: vi.fn(() =>
+          Promise.resolve({ error: { message: 'Delete failed' } })
+        ),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(servDeleteBoardPost(1)).rejects.toThrow();
+  });
+});
+
+describe('servIncrementBoardViewCount', () => {
+  it('조회수를 증가시킨다', async () => {
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: null, error: null })
+    ) as ReturnType<typeof vi.fn>;
+
+    await expect(servIncrementBoardViewCount(1)).resolves.toBeUndefined();
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('increment_board_views', {
+      target_post_id: 1,
+    });
+  });
+
+  it('에러 발생 시 예외를 던진다', async () => {
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: null, error: { message: 'RPC error' } })
+    ) as ReturnType<typeof vi.fn>;
+
+    await expect(servIncrementBoardViewCount(1)).rejects.toThrow();
+  });
+});
+
+describe('servAddBoardComment', () => {
+  it('댓글을 추가한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      insert: vi.fn(() => Promise.resolve({ error: null })),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(
+      servAddBoardComment({ postId: 1, content: '좋은 정보네요' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('미인증 사용자는 에러를 던진다', async () => {
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: null }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    await expect(
+      servAddBoardComment({ postId: 1, content: '댓글' })
+    ).rejects.toThrow('인증이 필요합니다');
+  });
+});
+
+describe('servDeleteBoardComment', () => {
+  it('본인 댓글을 정상적으로 삭제한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    const eqSecond = vi.fn(() =>
+      Promise.resolve({ error: null, count: 1 })
+    );
+    const eqFirst = vi.fn(() => ({ eq: eqSecond }));
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn(() => ({ eq: eqFirst })),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(servDeleteBoardComment(1)).resolves.toBeUndefined();
+    expect(eqFirst).toHaveBeenCalledWith('id', 1);
+    expect(eqSecond).toHaveBeenCalledWith('user_id', mockUser.id);
+  });
+
+  it('다른 사용자의 댓글 삭제 시 에러를 던진다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    const eqSecond = vi.fn(() =>
+      Promise.resolve({ error: null, count: 0 })
+    );
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn(() => ({ eq: vi.fn(() => ({ eq: eqSecond })) })),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(servDeleteBoardComment(99)).rejects.toThrow(
+      '삭제 권한이 없거나 존재하지 않는 댓글입니다.'
+    );
+  });
+
+  it('미인증 사용자는 에러를 던진다', async () => {
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: null }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    await expect(servDeleteBoardComment(1)).rejects.toThrow(
+      '인증이 필요합니다'
+    );
   });
 });

--- a/src/__tests__/services/sharing-services.test.ts
+++ b/src/__tests__/services/sharing-services.test.ts
@@ -1,12 +1,24 @@
 import { createClient } from '@/libs/supabase/client';
 import {
   servFetchSharingPosts,
-  servFetchPopularSearches,
+  servFetchSharingDetail,
+  servCreateSharingPost,
+  servDeleteSharingPost,
+  servIncrementSharingViewCount,
+  servAddSharingComment,
   servDeleteSharingComment,
+  servSearchSharingPosts,
+  servFetchPopularSearches,
 } from '@/services/sharing/sharing-services';
 import { createMockUser } from '../mocks/supabase';
-import { createMockSharingPost } from '../mocks/factories';
+import { createMockSharingPost, createMockSharingDetail } from '../mocks/factories';
 import type { MockSupabaseClient } from '../mocks/supabase';
+
+vi.mock('@/libs/supabase/storage', () => ({
+  uploadImage: vi.fn(() =>
+    Promise.resolve('https://test.supabase.co/storage/uploaded.jpg')
+  ),
+}));
 
 
 const mockSupabase = createClient() as unknown as MockSupabaseClient;
@@ -115,5 +127,218 @@ describe('servFetchPopularSearches', () => {
 
     expect(result).toHaveLength(2);
     expect(result[0]!.query).toBe('레고');
+  });
+});
+
+describe('servFetchSharingDetail', () => {
+  it('게시글 상세 정보를 반환한다', async () => {
+    const mockDetail = createMockSharingDetail();
+
+    const eqMock = vi.fn().mockReturnValue({
+      single: vi.fn(() =>
+        Promise.resolve({ data: mockDetail.post, error: null })
+      ),
+    });
+    const commentsEqMock = vi.fn().mockReturnValue({
+      order: vi.fn(() =>
+        Promise.resolve({ data: mockDetail.comments, error: null })
+      ),
+    });
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({ eq: eqMock }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnValue({ eq: commentsEqMock }),
+      };
+    }) as ReturnType<typeof vi.fn>;
+
+    const result = await servFetchSharingDetail(1);
+
+    expect(result.post.title).toBe('레고 교환합니다');
+    expect(result.comments).toHaveLength(1);
+  });
+
+  it('존재하지 않는 게시글이면 에러를 던진다', async () => {
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn(() =>
+            Promise.resolve({ data: null, error: { message: 'Not found' } })
+          ),
+        }),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(servFetchSharingDetail(999)).rejects.toThrow();
+  });
+});
+
+describe('servCreateSharingPost', () => {
+  it('게시글을 생성하고 반환한다', async () => {
+    const mockUser = createMockUser();
+    const mockPost = createMockSharingPost({ title: '새 장난감' });
+
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn(() =>
+            Promise.resolve({ data: mockPost, error: null })
+          ),
+        }),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    const result = await servCreateSharingPost({
+      title: '새 장난감',
+      content: '상태 좋습니다',
+      location: '광주광역시',
+      exchangeOption: '교환',
+      tags: ['장난감'],
+      image: new File(['test'], 'test.jpg', { type: 'image/jpeg' }),
+    });
+
+    expect(result.title).toBe('새 장난감');
+  });
+
+  it('미인증 사용자는 에러를 던진다', async () => {
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: null }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    await expect(
+      servCreateSharingPost({
+        title: '테스트',
+        content: '내용',
+        location: '광주',
+        exchangeOption: '교환',
+        tags: [],
+        image: new File(['test'], 'test.jpg', { type: 'image/jpeg' }),
+      })
+    ).rejects.toThrow('인증이 필요합니다');
+  });
+});
+
+describe('servDeleteSharingPost', () => {
+  it('게시글을 삭제한다', async () => {
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn().mockReturnValue({
+        eq: vi.fn(() => Promise.resolve({ error: null })),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(servDeleteSharingPost(1)).resolves.toBeUndefined();
+  });
+
+  it('에러 발생 시 예외를 던진다', async () => {
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn().mockReturnValue({
+        eq: vi.fn(() =>
+          Promise.resolve({ error: { message: 'Delete failed' } })
+        ),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(servDeleteSharingPost(1)).rejects.toThrow();
+  });
+});
+
+describe('servIncrementSharingViewCount', () => {
+  it('조회수를 증가시킨다', async () => {
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: null, error: null })
+    ) as ReturnType<typeof vi.fn>;
+
+    await expect(servIncrementSharingViewCount(1)).resolves.toBeUndefined();
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('increment_sharing_views', {
+      target_post_id: 1,
+    });
+  });
+
+  it('에러 발생 시 예외를 던진다', async () => {
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: null, error: { message: 'RPC error' } })
+    ) as ReturnType<typeof vi.fn>;
+
+    await expect(servIncrementSharingViewCount(1)).rejects.toThrow();
+  });
+});
+
+describe('servAddSharingComment', () => {
+  it('댓글을 추가한다', async () => {
+    const mockUser = createMockUser();
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: mockUser }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    mockSupabase.from = vi.fn(() => ({
+      insert: vi.fn(() => Promise.resolve({ error: null })),
+    })) as ReturnType<typeof vi.fn>;
+
+    await expect(
+      servAddSharingComment({ postId: 1, content: '좋은 장난감이네요' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('미인증 사용자는 에러를 던진다', async () => {
+    mockSupabase.auth = {
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: null }, error: null })
+      ),
+    } as typeof mockSupabase.auth;
+
+    await expect(
+      servAddSharingComment({ postId: 1, content: '댓글' })
+    ).rejects.toThrow('인증이 필요합니다');
+  });
+});
+
+describe('servSearchSharingPosts', () => {
+  it('검색 결과를 반환한다', async () => {
+    const mockPosts = [createMockSharingPost({ id: 1, title: '레고 교환' })];
+
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: [{ id: 1 }], error: null })
+    ) as ReturnType<typeof vi.fn>;
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn().mockReturnValue({
+        in: vi.fn().mockReturnValue({
+          order: vi.fn(() =>
+            Promise.resolve({ data: mockPosts, error: null })
+          ),
+        }),
+      }),
+    })) as ReturnType<typeof vi.fn>;
+
+    const result = await servSearchSharingPosts('레고');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.title).toBe('레고 교환');
+  });
+
+  it('검색 결과가 없으면 빈 배열을 반환한다', async () => {
+    mockSupabase.rpc = vi.fn(() =>
+      Promise.resolve({ data: [], error: null })
+    ) as ReturnType<typeof vi.fn>;
+
+    const result = await servSearchSharingPosts('존재하지않는검색어');
+
+    expect(result).toHaveLength(0);
   });
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -46,5 +46,23 @@ export default defineConfig({
     setupFiles: ['./src/vitest.setup.tsx'],
     css: false,
     exclude: ['node_modules', 'dodamduck_fe', '.next'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'text-summary'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.test.{ts,tsx}',
+        'src/__tests__/**',
+        'src/vitest.setup.tsx',
+        'src/types/**',
+        'src/components/ui/**',
+        'src/app/**/page.tsx',
+        'src/app/**/layout.tsx',
+        'src/app/**/route.ts',
+        'src/providers/**',
+        'src/libs/supabase/**',
+        'src/libs/query/**',
+      ],
+    },
   },
 });


### PR DESCRIPTION
작업 내용                                                 
  - Vitest 커버리지 측정 환경 구성 (@vitest/coverage-v8, provider/reporter/include/exclude 설정)
  - 서비스 레이어(auth, board, sharing) 테스트 보강 — 에러 핸들링, FormData 전송, 엣지 케이스 추가
  - 훅 테스트 보강(useAuth, useBoard, useChat, useSharing) 및 useLikes 신규 테스트 추가
  - 컴포넌트 테스트 신규 작성 (CommentSection, ConfirmDialog)
  - 유틸 테스트 보강(format-date 엣지케이스) 및 image-utils 신규 테스트 추가
  - 전체 테스트 수 104 → 178개 (+74, 71% 증가)
