### PR TITLE
fix(chat): Realtime 구독 유실 및 채팅창 스크롤 문제 수정

### DIFF
--- a/src/app/chat/[id]/components/ChatDetailContents.tsx
+++ b/src/app/chat/[id]/components/ChatDetailContents.tsx
@@ -117,8 +117,8 @@ export default function ChatDetailContents({ user, profile }: ChatDetailContents
           </div>
         </div>
 
-        <div className="flex flex-1 flex-col rounded-md border border-gray-200 bg-white">
-          <div className="flex items-center gap-3 border-b border-gray-200 p-4">
+        <div className="flex h-[70vh] flex-1 flex-col rounded-md border border-gray-200 bg-white md:h-[calc(100vh-8.5rem)]">
+          <div className="flex shrink-0 items-center gap-3 border-b border-gray-200 p-4">
             <Avatar className="h-10 w-10">
               <AvatarImage src={partnerProfile?.profile_url || undefined} />
               <AvatarFallback>
@@ -130,7 +130,7 @@ export default function ChatDetailContents({ user, profile }: ChatDetailContents
 
           <div
             ref={viewport}
-            className="scrollbar-brand h-100 flex-1 overflow-y-auto p-4"
+            className="scrollbar-brand min-h-0 flex-1 overflow-y-auto p-4"
           >
             <div className="flex flex-col gap-3">
               {messages?.map((msg) => {
@@ -168,7 +168,7 @@ export default function ChatDetailContents({ user, profile }: ChatDetailContents
             </div>
           </div>
 
-          <div className="flex items-center gap-2 border-t border-gray-200 p-3">
+          <div className="flex shrink-0 items-center gap-2 border-t border-gray-200 p-3">
             <Input
               placeholder="메시지를 입력하세요"
               value={message}

--- a/src/services/chat/useChat.ts
+++ b/src/services/chat/useChat.ts
@@ -9,6 +9,12 @@ export function useChatList() {
   return useQuery(chatQueries.list());
 }
 
+// realtime-js의 client.channel(topic)은 같은 토픽이면 기존 채널 객체를 재사용한다.
+// StrictMode 이중 마운트에서는 정리(unsubscribe) 중인 채널을 두 번째 마운트가 그대로
+// 재사용하고, 뒤늦게 도착한 teardown이 그 채널을 죽여서 에러 없이 이벤트만 끊긴다.
+// 구독마다 토픽을 다르게 만들어 재사용 자체를 막는다.
+let channelSeq = 0;
+
 export function useChatMessages(roomId: number) {
   const queryClient = useQueryClient();
 
@@ -19,7 +25,7 @@ export function useChatMessages(roomId: number) {
 
     const supabase = createClient();
     const channel = supabase
-      .channel(`chat-room-${roomId}`)
+      .channel(`chat-room-${roomId}-${++channelSeq}`)
       .on(
         'postgres_changes',
         {
@@ -30,10 +36,10 @@ export function useChatMessages(roomId: number) {
         },
         () => {
           queryClient.invalidateQueries({
-            queryKey: ['chat', 'messages', roomId],
+            queryKey: chatQueries.messages(roomId).queryKey,
           });
           queryClient.invalidateQueries({
-            queryKey: ['chat', 'list'],
+            queryKey: chatQueries.list().queryKey,
           });
         }
       )
@@ -60,7 +66,18 @@ export function useCreateChatRoom() {
 }
 
 export function useSendMessage() {
+  const queryClient = useQueryClient();
+
+  // Realtime 에코에만 의존하면 구독이 끊긴 동안 내가 보낸 메시지도 보이지 않는다.
   return useMutation({
     mutationFn: (request: SendMessageRequest) => servSendMessage(request),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: chatQueries.messages(variables.roomId).queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: chatQueries.list().queryKey,
+      });
+    },
   });
 }


### PR DESCRIPTION
 ## 작업 내용
  
  ### 1. Realtime 구독이 조용히 끊기는 문제 수정

  `supabase.channel(topic)`은 **같은 토픽이면 기존 채널 객체를 재사용**한다. React StrictMode의 이중 마운트 환경에서 다음 순서가 발생했다.

  1. 첫 마운트가 `chat-room-{id}` 채널을 구독
  2. StrictMode가 즉시 언마운트 → `removeChannel()` 시작
  3. 두 번째 마운트가 **정리 중인 같은 채널 객체를 그대로 재사용**
  4. 뒤늦게 완료된 teardown이 그 채널을 죽임

  결과적으로 **에러도 경고도 없이 이벤트 수신만 멈춰서**, 상대 메시지가 새로고침 전까지 보이지 않았다.

  - 구독마다 토픽에 시퀀스를 붙여(`chat-room-{id}-{seq}`) 채널 재사용 자체를 차단
  - 구독이 끊긴 상황에서도 최소한 내가 보낸 메시지는 보이도록 `useSendMessage`의 `onSuccess`에서 직접 invalidate (Realtime 에코 단독 의존 제거)
  - 하드코딩된 queryKey 배열(`['chat', 'messages', roomId]`)을 `chatQueries.*().queryKey` 참조로 교체해 키 정의를 `queries.ts` 한 곳으로 일원화

  ### 2. 채팅창 내부 스크롤 처리

  대화가 길어지면 페이지 전체가 늘어나 상대방 헤더와 메시지 입력창이 화면 밖으로 밀려났다. 컨테이너 높이를 고정하고 메시지 영역에만 `overflow-y`를 주어 헤더/입력창이 항상 보이도록 변경했다.

  ## 변경 파일

  - `src/services/chat/useChat.ts` — 채널 토픽에 시퀀스 부여, `useSendMessage` invalidate 추가, queryKey를 `chatQueries` 참조로 교체
  - `src/app/chat/[id]/components/ChatDetailContents.tsx` — 컨테이너 높이 고정(`h-[70vh]` / `md:h-[calc(100vh-8.5rem)]`), 헤더·입력창 `shrink-0`, 메시지 영역 `min-h-0 flex-1 overflow-y-auto`
